### PR TITLE
chore: retarget Dependabot from develop to master (Day-1 bootstrap)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,5 @@ updates:
     reviewers:
       - "Vasar007"
     # Raise pull requests for version updates
-    # to NuGet against the "develop" branch.
-    target-branch: "develop"
+    # to NuGet against the "master" branch.
+    target-branch: "master"


### PR DESCRIPTION
## Summary

Per D-14: retarget Dependabot from `develop` to `master` before Phase 1 code work begins.

This is the Day-1 bootstrap PR for Phase 1 (.NET & Solution Upgrades). It performs the first two steps of the bootstrap:

1. **Retargets `.github/dependabot.yml`** — changes `target-branch` from `"develop"` to `"master"`, so all future Dependabot PRs target `master` directly. This aligns with D-19 (no long-lived feature/phase-1 branch; each task PR targets `master`) and D-15 (`develop` will be retired at Phase 1 close).

2. **Files 10 Phase 1 Issues under `v0.9.7` milestone** (remote-only; no file change) — one Issue per requirement: NET-01 (#300), NET-02 (#301), NET-03 (#302), NET-04 (#303), NET-05 (#304), WORK-01 (#305), WORK-02 (#306), WORK-03 (#307), WORK-04 (#308), WORK-05 (#309). Every downstream Phase 1 PR can now satisfy WORK-03 (`closes #XXXX`) from its first commit.

## Phase 1 Planning Context

Planning artifacts live in `.planning/` (gitignored). Key decisions binding this PR:
- **D-13**: Reuse existing `v0.9.7` milestone (number: 11). No new milestone needed.
- **D-14**: Day-1 bootstrap must complete before any Phase 1 code work opens a PR.
- **D-15**: `develop` deleted from `origin` at Phase 1 close (after last PR merges, `v0.9.7` tag cut).
- **D-16**: Of the 5 Dependabot PRs currently targeting `develop`, all are closed (their bumps are superseded by Phase 1 bulk upgrade). Only `e64ce63` (ngrok config cleanup) from `develop` is cherry-picked into a separate Phase 1 PR.
- **D-19**: No long-lived `feature/phase-1` branch; each task PR targets `master` directly.
- **D-23**: Only existing labels used: `area: Dependencies`, `type: Code Maintenance`.

## Test Plan

- [x] `.github/dependabot.yml` contains exactly one `target-branch: "master"` and zero `target-branch: "develop"`.
- [x] File still contains `directory: "/ProjectV"`, `package-ecosystem: "nuget"`, all four labels, both assignees/reviewers.
- [x] All 10 Phase 1 Issues exist under `v0.9.7` milestone with labels `area: Dependencies` + `type: Code Maintenance`.
- [ ] After merge: close 5 open Dependabot PRs targeting `develop` with supersedure comment.

## Related Issues

closes #305

(WORK-01: Each phase tracked as a GitHub Milestone — this PR establishes the workflow that makes WORK-01 real for Phase 1.)