### PR TITLE
phase(01-03): bump TFMs to net10.0 and AutoMapper to 16.1.1 (gating PR)

### DIFF
--- a/ProjectV/Applications/ProjectV.ConsoleApp/Program.cs
+++ b/ProjectV/Applications/ProjectV.ConsoleApp/Program.cs
@@ -153,7 +153,7 @@ namespace ProjectV.ConsoleApp
                    .ConvertUsing(guid => JobId.Wrap(guid));
                 cfg.CreateMap<JobId, Guid>()
                    .ConvertUsing(jobId => jobId.Value);
-            });
+            }, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance);
             config.AssertConfigurationIsValid();
 
             var mapper = config.CreateMapper();

--- a/ProjectV/Directory.Build.props
+++ b/ProjectV/Directory.Build.props
@@ -4,10 +4,10 @@
   <PropertyGroup>
     <AppPlatforms>x64</AppPlatforms>
     <AppConfigurations>Debug;Release</AppConfigurations>
-    <AppTargetFramework>net8.0</AppTargetFramework>
-    <WindowsAppTargetFramework>net8.0-windows</WindowsAppTargetFramework>
-    <LibraryTargetFrameworks>net8.0</LibraryTargetFrameworks>
-    <TestTargetFrameworks>net8.0</TestTargetFrameworks>
+    <AppTargetFramework>net10.0</AppTargetFramework>
+    <WindowsAppTargetFramework>net10.0-windows</WindowsAppTargetFramework>
+    <LibraryTargetFrameworks>net10.0</LibraryTargetFrameworks>
+    <TestTargetFrameworks>net10.0</TestTargetFrameworks>
     <CSharpLangVersion>12.0</CSharpLangVersion>
     <FSharpLangVersion>8.0</FSharpLangVersion>
     <Nullable>enable</Nullable>

--- a/ProjectV/Directory.Packages.props
+++ b/ProjectV/Directory.Packages.props
@@ -3,7 +3,7 @@
   <ItemGroup>
     <PackageVersion Include="Acolyte.NET" Version="3.0.0-alpha.51" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
-    <PackageVersion Include="AutoMapper" Version="13.0.1" />
+    <PackageVersion Include="AutoMapper" Version="16.1.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.3" />
     <PackageVersion Include="CsvHelper" Version="33.0.1" />
     <PackageVersion Include="FileHelpers" Version="3.5.2" />
@@ -49,7 +49,7 @@
     <PackageVersion Include="RestSharp" Version="112.1.0" />
     <PackageVersion Include="SteamWebApiLib" Version="1.1.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-    <PackageVersion Include="System.Data.SqlClient" Version="4.9.0" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.9.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.0" />

--- a/ProjectV/Directory.Packages.props
+++ b/ProjectV/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.3.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
@@ -50,7 +50,7 @@
     <PackageVersion Include="SteamWebApiLib" Version="1.1.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.9.1" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.0" />
     <PackageVersion Include="Telegram.Bot" Version="22.2.0" />

--- a/ProjectV/Libraries/ProjectV.CommonCSharp/ProjectV.CommonCSharp.csproj
+++ b/ProjectV/Libraries/ProjectV.CommonCSharp/ProjectV.CommonCSharp.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Acolyte.NET" />
     <PackageReference Include="AutoMapper" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" />
   </ItemGroup>
 
 </Project>

--- a/ProjectV/Libraries/ProjectV.Crawlers/ProjectV.Crawlers.csproj
+++ b/ProjectV/Libraries/ProjectV.Crawlers/ProjectV.Crawlers.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="RestSharp" />
-    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ProjectV/Libraries/ProjectV.DataPipeline/ProjectV.DataPipeline.csproj
+++ b/ProjectV/Libraries/ProjectV.DataPipeline/ProjectV.DataPipeline.csproj
@@ -14,7 +14,6 @@
   <ItemGroup>
     <PackageReference Include="Gridsum.DataflowEx" />
     <PackageReference Include="System.Data.SqlClient" /> <!-- Have to explicitly use the latest version because "Gridsum.DataflowEx" has a vulnerable version of this package. -->
-    <PackageReference Include="System.Net.Http" /> <!-- Have to explicitly use the latest version because "Gridsum.DataflowEx" has a vulnerable version of this package. -->
   </ItemGroup>
 
   <ItemGroup>

--- a/ProjectV/WebServices/ProjectV.CommonWebApi/ProjectV.CommonWebApi.csproj
+++ b/ProjectV/WebServices/ProjectV.CommonWebApi/ProjectV.CommonWebApi.csproj
@@ -15,7 +15,6 @@
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" />

--- a/ProjectV/WebServices/ProjectV.CommunicationWebService/Program.cs
+++ b/ProjectV/WebServices/ProjectV.CommunicationWebService/Program.cs
@@ -1,7 +1,7 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using ProjectV.Logging;
 
 namespace ProjectV.CommunicationWebService
@@ -15,22 +15,18 @@ namespace ProjectV.CommunicationWebService
             LoggerFactory.CreateLoggerFor(typeof(Program));
 
 
-        private static IWebHostBuilder CreateWebHostBuilder(string[] args)
-        {
-            return WebHost
-                .CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
-        }
-
         private static async Task Main(string[] args)
         {
             try
             {
                 _logger.PrintHeader("Communication web service started.");
 
-                var host = CreateWebHostBuilder(args).Build();
+                var host = Host
+                    .CreateDefaultBuilder(args)
+                    .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>())
+                    .Build();
 
-                // Run the WebHost, and start accepting requests.
+                // Run the host, and start accepting requests.
                 // There's an async overload, so we may as well use it.
                 await host.RunAsync();
             }

--- a/ProjectV/WebServices/ProjectV.ConfigurationWebService/Program.cs
+++ b/ProjectV/WebServices/ProjectV.ConfigurationWebService/Program.cs
@@ -1,7 +1,7 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using ProjectV.Logging;
 
 namespace ProjectV.ConfigurationWebService
@@ -14,22 +14,18 @@ namespace ProjectV.ConfigurationWebService
         private static readonly ILogger _logger = LoggerFactory.CreateLoggerFor(typeof(Program));
 
 
-        private static IWebHostBuilder CreateWebHostBuilder(string[] args)
-        {
-            return WebHost
-                .CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
-        }
-
         private static async Task Main(string[] args)
         {
             try
             {
                 _logger.PrintHeader("Configuration web service started.");
 
-                var host = CreateWebHostBuilder(args).Build();
+                var host = Host
+                    .CreateDefaultBuilder(args)
+                    .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>())
+                    .Build();
 
-                // Run the WebHost, and start accepting requests.
+                // Run the host, and start accepting requests.
                 // There's an async overload, so we may as well use it.
                 await host.RunAsync();
             }

--- a/ProjectV/WebServices/ProjectV.ProcessingWebService/Program.cs
+++ b/ProjectV/WebServices/ProjectV.ProcessingWebService/Program.cs
@@ -1,8 +1,8 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using ProjectV.DataAccessLayer;
 using ProjectV.Logging;
 
@@ -16,18 +16,11 @@ namespace ProjectV.ProcessingWebService
         private static readonly ILogger _logger = LoggerFactory.CreateLoggerFor(typeof(Program));
 
 
-        private static IWebHostBuilder CreateWebHostBuilder(string[] args)
-        {
-            return WebHost
-                .CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
-        }
-
-        private static async Task CreateDbIfNotExistsAsync(IWebHost webHost)
+        private static async Task CreateDbIfNotExistsAsync(IHost host)
         {
             _logger.Info("Ensuring DB is existing.");
 
-            using var scope = webHost.Services.CreateScope();
+            using var scope = host.Services.CreateScope();
             IServiceProvider services = scope.ServiceProvider;
 
             try
@@ -59,11 +52,14 @@ namespace ProjectV.ProcessingWebService
             {
                 _logger.PrintHeader("Processing web service started.");
 
-                var host = CreateWebHostBuilder(args).Build();
+                var host = Host
+                    .CreateDefaultBuilder(args)
+                    .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>())
+                    .Build();
 
                 await CreateDbIfNotExistsAsync(host);
 
-                // Run the WebHost, and start accepting requests.
+                // Run the host, and start accepting requests.
                 // There's an async overload, so we may as well use it.
                 await host.RunAsync();
             }

--- a/ProjectV/WebServices/ProjectV.ProcessingWebService/Startup.cs
+++ b/ProjectV/WebServices/ProjectV.ProcessingWebService/Startup.cs
@@ -31,7 +31,7 @@ namespace ProjectV.ProcessingWebService
             services.AddTransient<ITargetServiceCreator, TargetServiceCreator>();
             services.AddScoped<IJobInfoService, DatabaseJobInfoService>();
 
-            services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
+            services.AddAutoMapper(cfg => cfg.AddMaps(AppDomain.CurrentDomain.GetAssemblies()));
             services.AddDbContext<ProjectVDbContext>();
 
             var jwtOptionsSecion = Configuration.GetSection(nameof(JwtOptions));

--- a/ProjectV/WebServices/ProjectV.TelegramBotWebService/Program.cs
+++ b/ProjectV/WebServices/ProjectV.TelegramBotWebService/Program.cs
@@ -1,8 +1,8 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using ProjectV.CommonWebApi.Service.Setup;
 using ProjectV.Logging;
 
@@ -16,29 +16,26 @@ namespace ProjectV.TelegramBotWebService
         private static readonly ILogger _logger = LoggerFactory.CreateLoggerFor(typeof(Program));
 
 
-        private static IWebHostBuilder CreateWebHostBuilder(string[] args)
-        {
-            return WebHost
-                .CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
-        }
-
         private static async Task Main(string[] args)
         {
             try
             {
                 _logger.PrintHeader("Telegram bot web service started.");
 
-                var host = CreateWebHostBuilder(args).Build();
+                var host = Host
+                    .CreateDefaultBuilder(args)
+                    .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>())
+                    .Build();
+
                 var serviceSetup = host.Services.GetRequiredService<IServiceSetup>();
 
                 // Execute pre-run actions.
                 await using (var onRunFailAction = await serviceSetup.PreRunAsync())
                 {
-                    // Run the WebHost, and start accepting requests.
+                    // Run the host, and start accepting requests.
                     await host.RunAsync();
 
-                    // If WebHost finished work without issues, cancel fail callback.
+                    // If host finished work without issues, cancel fail callback.
                     onRunFailAction.Cancel();
                 }
 


### PR DESCRIPTION
## Summary

Plan 01-03 — the **gating PR for all of Phase 1** (per D-20). Bumps every TFM variable from `net8.0`/`net8.0-windows` to `net10.0`/`net10.0-windows`, bumps AutoMapper from `13.0.1` to `16.1.1` to clear `NU1903` (`GHSA-rvv3-g6hj-g44x` StackOverflow DoS) which was failing CI under `TreatWarningsAsErrors=true`, and bumps `System.Data.SqlClient` from `4.9.0` to `4.9.1`.

In the same PR, the net10-mandated fixes that surfaced once those bumps were applied:

- `Microsoft.IdentityModel.Tokens` and `System.IdentityModel.Tokens.Jwt` bumped `8.3.0` → `8.14.0` to resolve `NU1605` (JWT 8.3.0 transitively requires Tokens >= 8.14.0). This was originally scoped to Plan 01-04 (category b) but had to land here to keep the restore green.
- 4 redundant `<PackageReference>` entries pruned (`NU1510`): `System.Threading.Tasks.Dataflow` in `ProjectV.CommonCSharp`; `System.Net.Http` in `ProjectV.Crawlers` and `ProjectV.DataPipeline`; `Microsoft.AspNetCore.Authorization` in `ProjectV.CommonWebApi`. All four are now included implicitly by the net10 framework reference.
- All 4 web service `Program.cs` migrated from `WebHost.CreateDefaultBuilder/UseStartup` to `Host.CreateDefaultBuilder + ConfigureWebHostDefaults` (the `WebHost` API was removed in net10).
- `ProcessingWebService/Startup.cs`: `services.AddAutoMapper(assemblies)` → `AddAutoMapper(cfg => cfg.AddMaps(assemblies))` (array overload removed in AutoMapper 16.x).
- `ConsoleApp/Program.cs` `TestAutomapper`: `MapperConfiguration` now requires `ILoggerFactory` as second arg; passed `NullLoggerFactory.Instance`.

closes #300
closes #301

refs #302 (NET-03 Linux x64 build — the green baseline this PR establishes)

## Test plan

- [x] `dotnet restore ProjectV/ProjectV.sln` — 0 errors, no NU1903/NU1605/NU1510 (on Linux x64 with .NET 10.0.107 SDK)
- [x] `dotnet build ProjectV/ProjectV.sln -c Debug -p:Platform=x64 --no-restore` — 0 warnings, 0 errors
- [x] `dotnet test ProjectV/ProjectV.sln -c Debug -p:Platform=x64 --no-build` — Appraisers 14 passed; Common 1 skipped (pre-existing); ContentDirectories (F#) 9 passed
- [x] `dotnet test ProjectV/Tests/ProjectV.ContentDirectories.Tests/ProjectV.ContentDirectories.Tests.fsproj --no-build` — 9 passed (explicit per CLAUDE.md convention)
- [ ] AppVeyor green on master after merge (Windows verification — not blocking; admin merge expected)