### PR TITLE
chore: bump Microsoft.* runtime stack + Swashbuckle 10.x + Npgsql 10.x + Asp.Versioning 10.x for net10 (cat b)

### DIFF
--- a/ProjectV/Directory.Packages.props
+++ b/ProjectV/Directory.Packages.props
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageVersion Include="Acolyte.NET" Version="3.0.0-alpha.51" />
-    <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.0" />
+    <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageVersion Include="AutoMapper" Version="16.1.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.3" />
     <PackageVersion Include="CsvHelper" Version="33.0.1" />
@@ -19,40 +19,40 @@
     <PackageVersion Include="MaterialDesignColors" Version="3.1.0" />
     <PackageVersion Include="MaterialDesignThemes" Version="5.1.0" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NLog" Version="5.3.4" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.15" />
     <PackageVersion Include="NLog.Schema" Version="5.3.4" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="OmdbApiNet" Version="1.3.0" />
     <PackageVersion Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
     <PackageVersion Include="Prism.Unity" Version="9.0.537" />
     <PackageVersion Include="Prism.Wpf" Version="9.0.537" />
     <PackageVersion Include="RestSharp" Version="112.1.0" />
     <PackageVersion Include="SteamWebApiLib" Version="1.1.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.9.1" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.0" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="10.0.8" />
     <PackageVersion Include="Telegram.Bot" Version="22.2.0" />
     <PackageVersion Include="TMDbLib" Version="2.2.0" />
     <PackageVersion Include="Unquote" Version="7.0.1" />

--- a/ProjectV/WebServices/ProjectV.CommonWebApi/Service/Extensions/ServiceCollectionExtensions.cs
+++ b/ProjectV/WebServices/ProjectV.CommonWebApi/Service/Extensions/ServiceCollectionExtensions.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using ProjectV.CommonWebApi.Models.Options;
 using ProjectV.CommonWebApi.Service.Hosted;
 


### PR DESCRIPTION
## What

Aligns all Microsoft.* runtime packages and strongly-coupled adjacent packages on the net10-stable line (category b per D-05), bundled in one PR because Swashbuckle 10.x brings Microsoft.OpenApi 2.x which has a breaking namespace reorganisation.

## Changes

**`ProjectV/Directory.Packages.props`** — 20 version bumps:

| Package | Old | New |
|---------|-----|-----|
| Microsoft.AspNetCore.Authentication.JwtBearer | 8.0.11 | 10.0.8 |
| Microsoft.AspNetCore.Authorization | 9.0.0 | 10.0.8 |
| Microsoft.AspNetCore.Mvc.NewtonsoftJson | 8.0.11 | 10.0.8 |
| Microsoft.EntityFrameworkCore | 9.0.0 | 10.0.8 |
| Microsoft.EntityFrameworkCore.Tools | 9.0.0 | 10.0.8 |
| Microsoft.Extensions.Configuration | 9.0.0 | 10.0.8 |
| Microsoft.Extensions.Configuration.Binder | 9.0.0 | 10.0.8 |
| Microsoft.Extensions.Configuration.Json | 9.0.0 | 10.0.8 |
| Microsoft.Extensions.DependencyInjection | 8.0.0 | 10.0.8 |
| Microsoft.Extensions.Hosting | 9.0.0 | 10.0.8 |
| Microsoft.Extensions.Hosting.Systemd | 9.0.0 | 10.0.8 |
| Microsoft.Extensions.Hosting.WindowsServices | 9.0.0 | 10.0.8 |
| Microsoft.Extensions.Http | 9.0.0 | 10.0.8 |
| Microsoft.Extensions.Http.Polly | 9.0.0 | 10.0.8 |
| System.Threading.Tasks.Dataflow | 9.0.0 | 10.0.8 |
| Microsoft.IdentityModel.Tokens | 8.14.0 | 8.18.0 |
| System.IdentityModel.Tokens.Jwt | 8.14.0 | 8.18.0 |
| Asp.Versioning.Mvc | 8.1.0 | 10.0.0 |
| Npgsql.EntityFrameworkCore.PostgreSQL | 9.0.2 | 10.0.1 |
| Swashbuckle.AspNetCore | 7.2.0 | 10.1.7 |

`Microsoft.EntityFrameworkCore.SqlServer` deliberately left at 9.0.0 (deferred to Plan 08 — D-11 removes it entirely).

**`WebServices/ProjectV.CommonWebApi/Service/Extensions/ServiceCollectionExtensions.cs`** — one-line fix:  
`using Microsoft.OpenApi.Models;` → `using Microsoft.OpenApi;`  
(Microsoft.OpenApi 2.x reorganised types into the root namespace; this is the only call site in the solution.)

## Pitfall 2 outcome (RESEARCH.md)

No `AddSecurityRequirement` / `OpenApiReference` / `ReferenceType.SecurityScheme` call sites exist anywhere in WebServices — confirmed by grep before and after bump. Pitfall 2 is a no-op.

## JWT compile validation (D-31)

`AddJtwAuthentication(JwtOptions)` in ServiceCollectionExtensions.cs — `SymmetricSecurityKey`, `TokenValidationParameters`, `JwtBearerDefaults` all compile clean under JwtBearer 10.0.8 + Wilson 8.18.0. Build IS the test for Phase 1.

## Npgsql 10 (Research Priority 11)

`SetPostgresVersion(12, 0)` in `ProjectVDbContext.OnConfiguring` remains valid in Npgsql 10.0.1. No IPNetwork/cidr columns in this codebase — the known return-type breaking change does not affect us.

## Asp.Versioning.Mvc 10.0.0

`VersionByNamespaceConvention` in `Asp.Versioning.Conventions` is stable across the major version jump — no type moves or namespace renames surfaced in build.

## Test results (Linux x64, .NET 10.0.107)

- `dotnet restore ProjectV/ProjectV.sln` → 0 errors, 0 warnings (no NU1903/NU1605/NU1510)
- `dotnet build ProjectV/ProjectV.sln --configuration Release --no-restore` → **0 warnings, 0 errors**
- `dotnet test ProjectV/ProjectV.sln --configuration Release --no-build` → Appraisers 14 passed, Common 1 skipped (pre-existing), ContentDirectories (F#) 9 passed

closes #300
closes #301