### PR TITLE
phase(01-05): bump test stack (xunit, Test.Sdk, coverlet, Moq) for net10

### DIFF
--- a/ProjectV/Directory.Packages.props
+++ b/ProjectV/Directory.Packages.props
@@ -4,7 +4,7 @@
     <PackageVersion Include="Acolyte.NET" Version="3.0.0-alpha.51" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageVersion Include="AutoMapper" Version="16.1.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="CsvHelper" Version="33.0.1" />
     <PackageVersion Include="FileHelpers" Version="3.5.2" />
     <PackageVersion Include="FSharp.Core" Version="8.0.400" />
@@ -35,8 +35,8 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="Moq" Version="4.20.70" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NLog" Version="5.3.4" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.15" />
@@ -56,8 +56,8 @@
     <PackageVersion Include="Telegram.Bot" Version="22.2.0" />
     <PackageVersion Include="TMDbLib" Version="2.2.0" />
     <PackageVersion Include="Unquote" Version="7.0.1" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Bumps the test stack to versions compatible with net10.0 (D-05 category (c)). Pure CPM edits in `ProjectV/Directory.Packages.props` — no production code touched.

### Bumps applied

| Package | From | To | Notes |
|---------|------|-----|-------|
| `xunit` | 2.9.2 | 2.9.3 | patch |
| `xunit.runner.visualstudio` | 3.0.0 | 3.1.5 | minor |
| `Microsoft.NET.Test.Sdk` | 17.12.0 | 18.5.1 | minor; net10-aligned |
| `coverlet.collector` | 6.0.3 | 10.0.0 | major; net10-aligned, no breaking collector API changes |
| `Moq` | 4.20.70 | 4.20.72 | minor; NSubstitute replacement deferred to Plan 11 per D-07 |

### Explicit no-ops

- `Unquote` stays at `7.0.1` (no new stable release)
- `FluentAssertions` stays at `6.7.0` (AwesomeAssertions replacement deferred to Plan 10 per D-07)

### Out of scope (not touched)

- `NSubstitute` — Plan 11 owns the Moq → NSubstitute migration
- `AwesomeAssertions` — Plan 10 owns the FluentAssertions → AwesomeAssertions migration
- `Mapperly` — Plan 12 owns AutoMapper → Mapperly migration

## Test plan

- [x] `dotnet restore ProjectV.sln` — succeeded, no NU1903/NU1605/NU1510 errors
- [x] `dotnet build ProjectV.sln -c Release` — succeeded, 0 warnings, 0 errors
- [x] `dotnet test ProjectV.sln -c Release --no-build` — 23 passed, 1 pre-existing skip, 0 failed
- [x] `dotnet test Tests/ProjectV.ContentDirectories.Tests/... -c Release -p:Platform=x64 --no-build` — 9 passed, 0 failed

Closes #300
Closes #301