### PR TITLE
phase(01-07): bump WPF stack (MaterialDesign + Ookii/Prism no-ops) for net10

### DIFF
--- a/ProjectV/Directory.Packages.props
+++ b/ProjectV/Directory.Packages.props
@@ -16,8 +16,8 @@
     <PackageVersion Include="Gridsum.DataflowEx" Version="2.0.0" />
     <PackageVersion Include="HttpToSocks5Proxy" Version="1.4.0" />
     <PackageVersion Include="JsonSubTypes" Version="2.0.1" />
-    <PackageVersion Include="MaterialDesignColors" Version="3.1.0" />
-    <PackageVersion Include="MaterialDesignThemes" Version="5.1.0" />
+    <PackageVersion Include="MaterialDesignColors" Version="5.3.2" />
+    <PackageVersion Include="MaterialDesignThemes" Version="5.3.2" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.8" />


### PR DESCRIPTION
## Summary

Category (e) — WPF-side package upgrades (D-05, D-12).

- **MaterialDesignThemes**: 5.1.0 → 5.3.2
- **MaterialDesignColors**: 3.1.0 → 5.3.2 (major version realignment with Themes; per Pitfall 6 in RESEARCH.md, bumped together in same PR)
- **Prism.Wpf**: 9.0.537 → 9.0.537 (no change — already latest; nuspec lists net10.0 as supported TFM)
- **Prism.Unity**: 9.0.537 → 9.0.537 (no change — already latest)
- **Ookii.Dialogs.Wpf**: 5.0.1 → 5.0.1 (no change — already latest)

No XAML or C# code changes required. The `BundledTheme` enum values (`DeepPurple`, `Lime`, `Inherit`), namespace URI (`http://materialdesigninxaml.net/winfx/xaml/themes`), and all control types (`DialogHost`, `DrawerHost`, `ColorZone`, `PopupBox`, `Card`, `HintAssist`, `PackIcon`) are stable in MaterialDesign 5.x per Assumption A4.

DesktopApp restores successfully on Linux with `-p:EnableWindowsTargeting=true`. WPF compile verification is delegated to AppVeyor (Windows), which builds `ProjectV.Desktop.sln` per D-04 and Plan 02.

## Test Plan

- [x] `dotnet restore ProjectV.sln` — clean, no NU errors
- [x] `dotnet build ProjectV.sln -c Release` — succeeded, 0 warnings, 0 errors
- [x] `dotnet test ProjectV.sln -c Release --no-build` — all tests pass (14 passed, 1 skipped, 0 failed)
- [x] `dotnet test Tests/ProjectV.ContentDirectories.Tests/ -c Release -p:Platform=x64 --no-build` — 9 passed, 0 failed
- [x] `dotnet restore Applications/ProjectV.DesktopApp/ProjectV.DesktopApp.csproj -p:EnableWindowsTargeting=true` — clean
- [ ] AppVeyor green on Desktop.sln (Windows CI; will verify after merge)

## Links

closes #301
closes #300
references #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)