### PR TITLE
phase(01-08): bump misc (Newtonsoft/CsvHelper/NLog) + remove EF SqlServer per D-11

### DIFF
--- a/ProjectV/Directory.Packages.props
+++ b/ProjectV/Directory.Packages.props
@@ -5,7 +5,7 @@
     <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageVersion Include="AutoMapper" Version="16.1.1" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="CsvHelper" Version="33.0.1" />
+    <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="FileHelpers" Version="3.5.2" />
     <PackageVersion Include="FSharp.Core" Version="8.0.400" />
     <PackageVersion Include="FluentAssertions" Version="6.7.0" />
@@ -23,7 +23,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
@@ -37,10 +36,10 @@
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NLog" Version="5.3.4" />
-    <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.15" />
-    <PackageVersion Include="NLog.Schema" Version="5.3.4" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="NLog" Version="6.1.3" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.3" />
+    <PackageVersion Include="NLog.Schema" Version="6.1.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="OmdbApiNet" Version="1.3.0" />
     <PackageVersion Include="Ookii.Dialogs.Wpf" Version="5.0.1" />

--- a/ProjectV/Libraries/ProjectV.DataAccessLayer/ProjectV.DataAccessLayer.csproj
+++ b/ProjectV/Libraries/ProjectV.DataAccessLayer/ProjectV.DataAccessLayer.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" PrivateAssets="All" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="System.Data.SqlClient" />

--- a/ProjectV/Libraries/ProjectV.Logging/NLog.xsd
+++ b/ProjectV/Libraries/ProjectV.Logging/NLog.xsd
@@ -6,6 +6,7 @@
       <xs:element name="extensions" type="NLogExtensions" />
       <xs:element name="include" type="NLogInclude" />
       <xs:element name="variable" type="NLogVariable" />
+      <xs:element name="variables" type="NLogVariables" />
       <xs:element name="targets" type="NLogTargets" />
       <xs:element name="rules" type="NLogRules" />
       <xs:element name="time" type="TimeSource" />
@@ -37,12 +38,12 @@
     </xs:attribute>
     <xs:attribute name="globalThreshold" type="NLogLevel">
       <xs:annotation>
-        <xs:documentation>Global log level threshold for application log messages. Messages below this level won't be logged..</xs:documentation>
+        <xs:documentation>Global log level threshold for application log messages. Messages below this level won't be logged.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="throwExceptions" type="xs:boolean">
       <xs:annotation>
-        <xs:documentation>Throw an exception when there is an internal error. Default value is: false.</xs:documentation>
+        <xs:documentation>Throw an exception when there is an internal error. Default value is: false. Not recommend to set to true in production!</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="throwConfigExceptions" type="xs:boolean">
@@ -72,7 +73,7 @@
     </xs:attribute>
     <xs:attribute name="parseMessageTemplates" type="xs:boolean">
       <xs:annotation>
-        <xs:documentation>Perform mesage template parsing and formatting of LogEvent messages (true = Always, false = Never, empty = Auto Detect). Default value is: empty.</xs:documentation>
+        <xs:documentation>Perform message template parsing and formatting of LogEvent messages (true = Always, false = Never, empty = Auto Detect). Default value is: empty.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
@@ -123,7 +124,7 @@
     </xs:choice>
     <xs:attribute name="name" use="optional">
       <xs:annotation>
-        <xs:documentation>Name of the logger. May include '*' character which acts like a wildcard. Allowed forms are: *, Name, *Name, Name* and *Name*</xs:documentation>
+        <xs:documentation>Filter on the name of the logger. May include wildcard characters ('*' or '?').</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="levels" type="NLogLevelList">
@@ -158,7 +159,17 @@
     </xs:attribute>
     <xs:attribute name="enabled" type="xs:boolean" default="true">
       <xs:annotation>
-        <xs:documentation>Enable or disable logging rule. Disabled rules are ignored.</xs:documentation>
+        <xs:documentation>Enable this rule. Note: disabled rules aren't available from the API.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="ruleName" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>Rule identifier to allow rule lookup with Configuration.FindRuleByName and Configuration.RemoveRuleByName.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="finalMinLevel" type="NLogLevel" use="optional">
+      <xs:annotation>
+        <xs:documentation>Loggers matching will be restricted to specified minimum level for following rules.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
@@ -171,6 +182,11 @@
       <xs:element name="whenNotEqual" type="whenNotEqual" />
       <xs:element name="whenRepeated" type="whenRepeated" />
     </xs:choice>
+    <xs:attribute name="defaultAction" type="FilterResult">
+      <xs:annotation>
+        <xs:documentation>Default action if none of the filters match.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
   <xs:simpleType name="NLogLevel">
     <xs:restriction base="xs:string">
@@ -210,16 +226,33 @@
     </xs:attribute>
   </xs:complexType>
   <xs:complexType name="NLogVariable">
+    <xs:choice minOccurs="0" maxOccurs="1">
+      <xs:element name="value" minOccurs="0" maxOccurs="1" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Variable value. Note, the 'value' attribute has precedence over this one.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout">
+        <xs:annotation>
+          <xs:documentation>Layout type variable value. Note, the 'value' attribute has precedence over this one.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:choice>
     <xs:attribute name="name" type="xs:string" use="required">
       <xs:annotation>
         <xs:documentation>Variable name.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="value" type="SimpleLayoutAttribute" use="required">
+    <xs:attribute name="value" type="SimpleLayoutAttribute">
       <xs:annotation>
         <xs:documentation>Variable value.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="NLogVariables">
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="variable" type="NLogVariable" />
+    </xs:sequence>
   </xs:complexType>
   <xs:simpleType name="NLogTargetIDList">
     <xs:restriction base="xs:string">
@@ -270,31 +303,73 @@
       <xs:minLength value="1" />
     </xs:restriction>
   </xs:simpleType>
-  <xs:complexType name="AsyncWrapper">
+  <xs:complexType name="AspNetBufferingWrapper">
     <xs:complexContent>
       <xs:extension base="WrapperTargetBase">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="batchSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="fullBatchSizeWriteLimit" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="overflowAction" minOccurs="0" maxOccurs="1" type="NLog.Targets.Wrappers.AsyncTargetWrapperOverflowAction" />
-          <xs:element name="queueLimit" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="timeToSleepBetweenBatches" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="bufferGrowLimit" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="bufferSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="100" />
+          <xs:element name="growBufferAsNeeded" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="batchSize" type="xs:integer">
+        <xs:attribute name="bufferGrowLimit" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>Number of log events that should be processed in a batch by the lazy writer thread.</xs:documentation>
+            <xs:documentation>Maximum number of log events that the buffer can keep.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="fullBatchSizeWriteLimit" type="xs:integer">
+        <xs:attribute name="bufferSize" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>Limit of full s to write before yielding into  Performance is better when writing many small batches, than writing a single large batch</xs:documentation>
+            <xs:documentation>Number of log events to be buffered.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="growBufferAsNeeded" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether buffer should grow as needed.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="AspNetTrace">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Layout used to format log messages.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="AsyncWrapper">
+    <xs:complexContent>
+      <xs:extension base="WrapperTargetBase">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="overflowAction" type="NLog.Targets.Wrappers.AsyncTargetWrapperOverflowAction" minOccurs="0" maxOccurs="1" default="Discard" />
+          <xs:element name="queueLimit" type="xs:integer" minOccurs="0" maxOccurs="1" default="10000" />
+          <xs:element name="batchSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="200" />
+          <xs:element name="forceLockingQueue" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="fullBatchSizeWriteLimit" type="xs:integer" minOccurs="0" maxOccurs="1" default="10" />
+          <xs:element name="timeToSleepBetweenBatches" type="xs:integer" minOccurs="0" maxOccurs="1" default="1" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="overflowAction" type="NLog.Targets.Wrappers.AsyncTargetWrapperOverflowAction">
@@ -307,14 +382,24 @@
             <xs:documentation>Limit on the number of requests in the lazy writer thread request queue.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="timeToSleepBetweenBatches" type="xs:integer">
+        <xs:attribute name="batchSize" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>Time in milliseconds to sleep between batches.</xs:documentation>
+            <xs:documentation>Number of log events that should be processed in a batch by the lazy writer thread.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+        <xs:attribute name="forceLockingQueue" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Whether to use the locking queue, instead of a lock-free concurrent queue</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fullBatchSizeWriteLimit" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Number of batches of P:NLog.Targets.Wrappers.AsyncTargetWrapper.BatchSize to write before yielding into P:NLog.Targets.Wrappers.AsyncTargetWrapper.TimeToSleepBetweenBatches</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="timeToSleepBetweenBatches" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Time in milliseconds to sleep between batches. (1 or less means trigger on new activity)</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -327,15 +412,215 @@
       <xs:enumeration value="Block" />
     </xs:restriction>
   </xs:simpleType>
+  <xs:complexType name="AtomFile">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="fileName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="writeHeaderWhenInitialFileNotEmpty" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="writeFooterOnArchivingOnly" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="maxArchiveDays" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="archiveSuffixFormat" type="xs:string" minOccurs="0" maxOccurs="1" default="_{0:00}" />
+          <xs:element name="maxArchiveFiles" type="xs:integer" minOccurs="0" maxOccurs="1" default="-1" />
+          <xs:element name="archiveFileName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="archiveEvery" type="NLog.Targets.FileArchivePeriod" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="archiveAboveSize" type="xs:long" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="archiveOldFileOnStartup" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="concurrentWrites" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="discardAll" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="writeBom" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="enableFileDelete" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="deleteOldFileOnStartup" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="createDirs" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="encoding" type="xs:string" minOccurs="0" maxOccurs="1" default="utf-8" />
+          <xs:element name="replaceFileContentsOnEachWrite" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="lineEnding" type="LineEndingMode" minOccurs="0" maxOccurs="1" />
+          <xs:element name="openFileCacheTimeout" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="bufferSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="32768" />
+          <xs:element name="autoFlush" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="keepFileOpen" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="openFileFlushTimeout" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="openFileCacheSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="5" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fileName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Name of the file to write to.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="header" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Header.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="footer" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Footer.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="writeHeaderWhenInitialFileNotEmpty" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to write the Header on initial creation of file appender, even if the file is not empty. Default value is false, which means only write header when initial file is empty (Ex. ensures valid CSV files)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="writeFooterOnArchivingOnly" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether the footer should be written only when the file is archived.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxArchiveDays" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum days of archive files that should be kept. Zero or negative means disabled.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="archiveSuffixFormat" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Format-string to convert archive sequence-number by using string.Format</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxArchiveFiles" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum number of archive files that should be kept. Negative means disabled.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="archiveFileName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Legacy archive logic where file-archive-logic moves active file to path specified by P:NLog.Targets.FileTarget.ArchiveFileName, and then recreates the active file. Use P:NLog.Targets.FileTarget.ArchiveSuffixFormat to control suffix format, instead of now obsolete token {#}</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="archiveEvery" type="NLog.Targets.FileArchivePeriod">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to trigger archive operation based on time-period, by moving active-file to file-path specified by P:NLog.Targets.FileTarget.ArchiveFileName</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="archiveAboveSize" type="xs:long">
+          <xs:annotation>
+            <xs:documentation>Size in bytes above which log files will be automatically archived. Zero or negative means disabled.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="archiveOldFileOnStartup" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether any existing log-file should be archived on startup.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="concurrentWrites" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether concurrent writes to the log file by multiple processes on the same host.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
+        <xs:attribute name="discardAll" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether or not this target should just discard all data that its asked to write. Mostly used for when testing NLog Stack except final write</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="writeBom" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to write BOM (byte order mark) in created files.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enableFileDelete" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to enable log file(s) to be deleted.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="deleteOldFileOnStartup" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to delete old log file on startup.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="createDirs" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to create directories if they do not exist.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="encoding" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>File encoding.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="replaceFileContentsOnEachWrite" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to replace file contents on each write instead of appending log message at the end.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="lineEnding" type="LineEndingMode">
+          <xs:annotation>
+            <xs:documentation>Line ending mode.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="openFileCacheTimeout" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum number of seconds that files are kept open. Zero or negative means disabled.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="bufferSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Log file buffer size in bytes.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="autoFlush" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to automatically flush the file buffers after each log message.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepFileOpen" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to keep log file open instead of opening and closing it on each logging event.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="openFileFlushTimeout" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum number of seconds before open files are flushed. Zero or negative means disabled.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="openFileCacheSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum number of files to be kept open.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="NLog.Targets.FileArchivePeriod">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None" />
+      <xs:enumeration value="Year" />
+      <xs:enumeration value="Month" />
+      <xs:enumeration value="Day" />
+      <xs:enumeration value="Hour" />
+      <xs:enumeration value="Minute" />
+      <xs:enumeration value="Sunday" />
+      <xs:enumeration value="Monday" />
+      <xs:enumeration value="Tuesday" />
+      <xs:enumeration value="Wednesday" />
+      <xs:enumeration value="Thursday" />
+      <xs:enumeration value="Friday" />
+      <xs:enumeration value="Saturday" />
+    </xs:restriction>
+  </xs:simpleType>
   <xs:complexType name="AutoFlushWrapper">
     <xs:complexContent>
       <xs:extension base="WrapperTargetBase">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="asyncFlush" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="condition" minOccurs="0" maxOccurs="1" type="Condition" />
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="asyncFlush" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="condition" type="Condition" minOccurs="0" maxOccurs="1" />
+          <xs:element name="flushOnConditionOnly" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
         </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="asyncFlush" type="xs:boolean">
           <xs:annotation>
             <xs:documentation>Delay the flush until the LogEvent has been confirmed as written</xs:documentation>
@@ -346,14 +631,9 @@
             <xs:documentation>Condition expression. Log events who meet this condition will cause a flush on the wrapped target.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="name" type="xs:string">
+        <xs:attribute name="flushOnConditionOnly" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Name of the target.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Only flush when LogEvent matches condition. Ignore explicit-flush, config-reload-flush and shutdown-flush</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -363,12 +643,11 @@
     <xs:complexContent>
       <xs:extension base="WrapperTargetBase">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="bufferSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="flushTimeout" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="overflowAction" minOccurs="0" maxOccurs="1" type="NLog.Targets.Wrappers.BufferingTargetWrapperOverflowAction" />
-          <xs:element name="slidingTimeout" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="bufferSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="100" />
+          <xs:element name="overflowAction" type="NLog.Targets.Wrappers.BufferingTargetWrapperOverflowAction" minOccurs="0" maxOccurs="1" default="Flush" />
+          <xs:element name="flushTimeout" type="xs:integer" minOccurs="0" maxOccurs="1" default="-1" />
+          <xs:element name="slidingTimeout" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
@@ -380,24 +659,19 @@
             <xs:documentation>Number of log events to be buffered.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="flushTimeout" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Timeout (in milliseconds) after which the contents of buffer will be flushed if there's no write in the specified period of time. Use -1 to disable timed flushes.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="overflowAction" type="NLog.Targets.Wrappers.BufferingTargetWrapperOverflowAction">
           <xs:annotation>
             <xs:documentation>Action to take if the buffer overflows.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="flushTimeout" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Timeout (in milliseconds) after which the contents of buffer will be flushed if there's no write in the specified period of time. Use -1 to disable timed flushes.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="slidingTimeout" type="xs:boolean">
           <xs:annotation>
             <xs:documentation>Indicates whether to use sliding timeout.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -409,225 +683,28 @@
       <xs:enumeration value="Discard" />
     </xs:restriction>
   </xs:simpleType>
-  <xs:complexType name="Chainsaw">
-    <xs:complexContent>
-      <xs:extension base="Target">
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="encoding" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="lineEnding" minOccurs="0" maxOccurs="1" type="LineEndingMode" />
-          <xs:element name="maxMessageSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="newLine" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="onConnectionOverflow" minOccurs="0" maxOccurs="1" type="NLog.Targets.NetworkTargetConnectionsOverflowAction" />
-          <xs:element name="maxQueueSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="maxConnections" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="keepConnection" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="connectionCacheSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="address" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="onOverflow" minOccurs="0" maxOccurs="1" type="NLog.Targets.NetworkTargetOverflowAction" />
-          <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.NLogViewerParameterInfo" />
-          <xs:element name="ndlcItemSeparator" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="ndcItemSeparator" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="includeNLogData" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeSourceInfo" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeNdlc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeNdc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeMdlc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeMdc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeCallSite" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeAllProperties" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="appInfo" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="loggerName" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-        </xs:choice>
-        <xs:attribute name="name" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>Name of the target.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="encoding" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>Encoding to be used.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="layout" type="SimpleLayoutAttribute">
-          <xs:annotation>
-            <xs:documentation>Instance of  that is used to format log messages.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="lineEnding" type="LineEndingMode">
-          <xs:annotation>
-            <xs:documentation>End of line value if a newline is appended at the end of log message .</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="maxMessageSize" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Maximum message size in bytes.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="newLine" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to append newline at the end of log message.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="onConnectionOverflow" type="NLog.Targets.NetworkTargetConnectionsOverflowAction">
-          <xs:annotation>
-            <xs:documentation>Action that should be taken if the will be more connections than .</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="maxQueueSize" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Maximum queue size.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="maxConnections" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Maximum current connections. 0 = no maximum.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="keepConnection" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to keep connection open whenever possible.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="connectionCacheSize" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Size of the connection cache (number of connections which are kept alive).</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="address" type="SimpleLayoutAttribute">
-          <xs:annotation>
-            <xs:documentation>Network address.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="onOverflow" type="NLog.Targets.NetworkTargetOverflowAction">
-          <xs:annotation>
-            <xs:documentation>Action that should be taken if the message is larger than maxMessageSize.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="ndlcItemSeparator" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>NDLC item separator.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="ndcItemSeparator" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>NDC item separator.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeNLogData" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include NLog-specific extensions to log4j schema.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeSourceInfo" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include source info (file name and line number) in the information sent over the network.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeNdlc" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include contents of the  stack.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeNdc" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include  stack contents.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeMdlc" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include  dictionary contents.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeMdc" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include  dictionary contents.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeCallSite" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include call site (class and method name) in the information sent over the network.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeAllProperties" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Option to include all properties from the log events</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="appInfo" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>AppInfo field. By default it's the friendly name of the current AppDomain.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="loggerName" type="SimpleLayoutAttribute">
-          <xs:annotation>
-            <xs:documentation>Renderer for log4j:event logger-xml-attribute (Default ${logger})</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:simpleType name="NLog.Targets.NetworkTargetConnectionsOverflowAction">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="AllowNewConnnection" />
-      <xs:enumeration value="DiscardMessage" />
-      <xs:enumeration value="Block" />
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:simpleType name="NLog.Targets.NetworkTargetOverflowAction">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="Error" />
-      <xs:enumeration value="Split" />
-      <xs:enumeration value="Discard" />
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:complexType name="NLog.Targets.NLogViewerParameterInfo">
-    <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-      <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-    </xs:choice>
-    <xs:attribute name="layout" type="SimpleLayoutAttribute">
-      <xs:annotation>
-        <xs:documentation>Layout that should be use to calcuate the value for the parameter.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="name" type="xs:string">
-      <xs:annotation>
-        <xs:documentation>Viewer parameter name.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-  </xs:complexType>
   <xs:complexType name="ColoredConsole">
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="header" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="footer" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="detectConsoleAvailable" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="encoding" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="errorStream" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="useDefaultRowHighlightingRules" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="detectConsoleAvailable" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="enableAnsiOutput" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="encoding" type="xs:string" minOccurs="0" maxOccurs="1" default="IBM437" />
+          <xs:element name="noColor" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+          <xs:element name="stdErr" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+          <xs:element name="autoFlush" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="detectOutputRedirected" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="useDefaultRowHighlightingRules" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
           <xs:element name="highlight-row" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.ConsoleRowHighlightingRule" />
           <xs:element name="highlight-word" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.ConsoleWordHighlightingRule" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="layout" type="SimpleLayoutAttribute">
-          <xs:annotation>
-            <xs:documentation>Text to be rendered.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="header" type="SimpleLayoutAttribute">
@@ -642,17 +719,37 @@
         </xs:attribute>
         <xs:attribute name="detectConsoleAvailable" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Indicates whether to auto-check if the console is available. - Disables console writing if Environment.UserInteractive = False (Windows Service) - Disables console writing if Console Standard Input is not available (Non-Console-App)</xs:documentation>
+            <xs:documentation>Indicates whether to auto-check if the console is available. - Disables console writing if Environment.UserInteractive = false (Windows Service) - Disables console writing if Console Standard Input is not available (Non-Console-App)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enableAnsiOutput" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Enables output using ANSI Color Codes</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="encoding" type="xs:string">
           <xs:annotation>
-            <xs:documentation>The encoding for writing messages to the .</xs:documentation>
+            <xs:documentation>The encoding for writing messages to the T:System.Console.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="errorStream" type="xs:boolean">
+        <xs:attribute name="noColor" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Indicates whether the error stream (stderr) should be used instead of the output stream (stdout).</xs:documentation>
+            <xs:documentation>Support NO_COLOR=1 environment variable. See also https://no-color.org/</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="stdErr" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to send the log messages to the standard error instead of the standard output.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="autoFlush" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to auto-flush after M:System.Console.WriteLine</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="detectOutputRedirected" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to auto-check if the console has been redirected to file - Disables coloring logic when System.Console.IsOutputRedirected = true</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="useDefaultRowHighlightingRules" type="xs:boolean">
@@ -660,11 +757,7 @@
             <xs:documentation>Indicates whether to use default row highlighting rules.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -691,18 +784,18 @@
   </xs:simpleType>
   <xs:complexType name="NLog.Targets.ConsoleRowHighlightingRule">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="condition" minOccurs="0" maxOccurs="1" type="Condition" />
-      <xs:element name="backgroundColor" minOccurs="0" maxOccurs="1" type="NLog.Targets.ConsoleOutputColor" />
-      <xs:element name="foregroundColor" minOccurs="0" maxOccurs="1" type="NLog.Targets.ConsoleOutputColor" />
+      <xs:element name="backgroundColor" type="NLog.Targets.ConsoleOutputColor" minOccurs="0" maxOccurs="1" default="NoChange" />
+      <xs:element name="condition" type="Condition" minOccurs="0" maxOccurs="1" />
+      <xs:element name="foregroundColor" type="NLog.Targets.ConsoleOutputColor" minOccurs="0" maxOccurs="1" default="NoChange" />
     </xs:choice>
-    <xs:attribute name="condition" type="Condition">
-      <xs:annotation>
-        <xs:documentation>Condition that must be met in order to set the specified foreground and background color.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
     <xs:attribute name="backgroundColor" type="NLog.Targets.ConsoleOutputColor">
       <xs:annotation>
         <xs:documentation>Background color.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="condition" type="Condition">
+      <xs:annotation>
+        <xs:documentation>Condition that must be met in order to set the specified foreground and background color.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="foregroundColor" type="NLog.Targets.ConsoleOutputColor">
@@ -713,42 +806,22 @@
   </xs:complexType>
   <xs:complexType name="NLog.Targets.ConsoleWordHighlightingRule">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="compileRegex" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-      <xs:element name="ignoreCase" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-      <xs:element name="regex" minOccurs="0" maxOccurs="1" type="xs:string" />
-      <xs:element name="text" minOccurs="0" maxOccurs="1" type="xs:string" />
-      <xs:element name="wholeWords" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-      <xs:element name="backgroundColor" minOccurs="0" maxOccurs="1" type="NLog.Targets.ConsoleOutputColor" />
-      <xs:element name="foregroundColor" minOccurs="0" maxOccurs="1" type="NLog.Targets.ConsoleOutputColor" />
+      <xs:element name="backgroundColor" type="NLog.Targets.ConsoleOutputColor" minOccurs="0" maxOccurs="1" default="NoChange" />
+      <xs:element name="condition" type="Condition" minOccurs="0" maxOccurs="1" />
+      <xs:element name="foregroundColor" type="NLog.Targets.ConsoleOutputColor" minOccurs="0" maxOccurs="1" default="NoChange" />
+      <xs:element name="ignoreCase" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+      <xs:element name="text" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="wholeWords" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+      <xs:element name="words" type="xs:string" minOccurs="0" maxOccurs="1" />
     </xs:choice>
-    <xs:attribute name="compileRegex" type="xs:boolean">
-      <xs:annotation>
-        <xs:documentation>Compile the ? This can improve the performance, but at the costs of more memory usage. If false, the Regex Cache is used.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="ignoreCase" type="xs:boolean">
-      <xs:annotation>
-        <xs:documentation>Indicates whether to ignore case when comparing texts.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="regex" type="xs:string">
-      <xs:annotation>
-        <xs:documentation>Regular expression to be matched. You must specify either text or regex.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="text" type="xs:string">
-      <xs:annotation>
-        <xs:documentation>Text to be matched. You must specify either text or regex.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="wholeWords" type="xs:boolean">
-      <xs:annotation>
-        <xs:documentation>Indicates whether to match whole words only.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
     <xs:attribute name="backgroundColor" type="NLog.Targets.ConsoleOutputColor">
       <xs:annotation>
         <xs:documentation>Background color.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="condition" type="Condition">
+      <xs:annotation>
+        <xs:documentation>Condition that must be met before scanning the row for highlight of words</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="foregroundColor" type="NLog.Targets.ConsoleOutputColor">
@@ -756,28 +829,44 @@
         <xs:documentation>Foreground color.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="ignoreCase" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Indicates whether to ignore case when comparing texts.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="text" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Text to be matched for Highlighting.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="wholeWords" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Indicates whether to match whole words only.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="words" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>List of words to be matched for Highlighting.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
   <xs:complexType name="Console">
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="header" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="footer" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="detectConsoleAvailable" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="encoding" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="error" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="autoFlush" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="detectConsoleAvailable" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="encoding" type="xs:string" minOccurs="0" maxOccurs="1" default="IBM437" />
+          <xs:element name="forceWriteLine" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="stdErr" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="layout" type="SimpleLayoutAttribute">
-          <xs:annotation>
-            <xs:documentation>Text to be rendered.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="header" type="SimpleLayoutAttribute">
@@ -790,26 +879,32 @@
             <xs:documentation>Footer.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="autoFlush" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to auto-flush after M:System.Console.WriteLine</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="detectConsoleAvailable" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Indicates whether to auto-check if the console is available - Disables console writing if Environment.UserInteractive = False (Windows Service) - Disables console writing if Console Standard Input is not available (Non-Console-App)</xs:documentation>
+            <xs:documentation>Indicates whether to auto-check if the console is available - Disables console writing if Environment.UserInteractive = false (Windows Service) - Disables console writing if Console Standard Input is not available (Non-Console-App)</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="encoding" type="xs:string">
           <xs:annotation>
-            <xs:documentation>The encoding for writing messages to the .</xs:documentation>
+            <xs:documentation>The encoding for writing messages to the T:System.Console.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="error" type="xs:boolean">
+        <xs:attribute name="forceWriteLine" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to force M:System.Console.WriteLine (slower) instead of the faster internal buffering.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="stdErr" type="xs:boolean">
           <xs:annotation>
             <xs:documentation>Indicates whether to send the log messages to the standard error instead of the standard output.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -817,32 +912,28 @@
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="useTransactions" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="dbUserName" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="dbProvider" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="dbPassword" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="keepConnection" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="dbDatabase" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="connectionStringName" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="connectionString" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="dbHost" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="installConnectionString" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="install-command" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.DatabaseCommandInfo" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="dbUserName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="dbPassword" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="dbDatabase" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="connectionStringName" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="dbHost" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="commandproperty" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.DatabaseObjectPropertyInfo" />
+          <xs:element name="keepConnection" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="dbProvider" type="xs:string" minOccurs="0" maxOccurs="1" default="sqlserver" />
+          <xs:element name="connectionString" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="connectionproperty" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.DatabaseObjectPropertyInfo" />
           <xs:element name="uninstall-command" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.DatabaseCommandInfo" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="installConnectionString" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="install-command" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.DatabaseCommandInfo" />
+          <xs:element name="isolationLevel" type="System.Data.IsolationLevel" minOccurs="0" maxOccurs="1" />
+          <xs:element name="commandText" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="commandType" type="System.Data.CommandType" minOccurs="0" maxOccurs="1" default="Text" />
           <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.DatabaseParameterInfo" />
-          <xs:element name="commandText" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="commandType" minOccurs="0" maxOccurs="1" type="System.Data.CommandType" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="useTransactions" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Obsolete - value will be ignored! The logging code always runs outside of transaction. Gets or sets a value indicating whether to use database transactions. Some data providers require this.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="dbUserName" type="SimpleLayoutAttribute">
@@ -850,19 +941,9 @@
             <xs:documentation>Database user name. If the ConnectionString is not provided this value will be used to construct the "User ID=" part of the connection string.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="dbProvider" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>Name of the database provider.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="dbPassword" type="SimpleLayoutAttribute">
           <xs:annotation>
             <xs:documentation>Database password. If the ConnectionString is not provided this value will be used to construct the "Password=" part of the connection string.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="keepConnection" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to keep the database connection open between the log events.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="dbDatabase" type="SimpleLayoutAttribute">
@@ -875,14 +956,24 @@
             <xs:documentation>Name of the connection string (as specified in &lt;connectionStrings&gt; configuration section.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="connectionString" type="SimpleLayoutAttribute">
-          <xs:annotation>
-            <xs:documentation>Connection string. When provided, it overrides the values specified in DBHost, DBUserName, DBPassword, DBDatabase.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="dbHost" type="SimpleLayoutAttribute">
           <xs:annotation>
             <xs:documentation>Database host name. If the ConnectionString is not provided this value will be used to construct the "Server=" part of the connection string.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepConnection" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to keep the database connection open between the log events.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="dbProvider" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the database provider.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="connectionString" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Connection string. When provided, it overrides the values specified in DBHost, DBUserName, DBPassword, DBDatabase.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="installConnectionString" type="SimpleLayoutAttribute">
@@ -890,9 +981,9 @@
             <xs:documentation>Connection string using for installation and uninstallation. If not provided, regular ConnectionString is being used.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+        <xs:attribute name="isolationLevel" type="System.Data.IsolationLevel">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Configures isolated transaction batch writing. If supported by the database, then it will improve insert performance.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="commandText" type="SimpleLayoutAttribute">
@@ -915,13 +1006,89 @@
       <xs:enumeration value="TableDirect" />
     </xs:restriction>
   </xs:simpleType>
+  <xs:simpleType name="System.Data.DbType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="AnsiString" />
+      <xs:enumeration value="Binary" />
+      <xs:enumeration value="Byte" />
+      <xs:enumeration value="Boolean" />
+      <xs:enumeration value="Currency" />
+      <xs:enumeration value="Date" />
+      <xs:enumeration value="DateTime" />
+      <xs:enumeration value="Decimal" />
+      <xs:enumeration value="Double" />
+      <xs:enumeration value="Guid" />
+      <xs:enumeration value="Int16" />
+      <xs:enumeration value="Int32" />
+      <xs:enumeration value="Int64" />
+      <xs:enumeration value="Object" />
+      <xs:enumeration value="SByte" />
+      <xs:enumeration value="Single" />
+      <xs:enumeration value="String" />
+      <xs:enumeration value="Time" />
+      <xs:enumeration value="UInt16" />
+      <xs:enumeration value="UInt32" />
+      <xs:enumeration value="UInt64" />
+      <xs:enumeration value="VarNumeric" />
+      <xs:enumeration value="AnsiStringFixedLength" />
+      <xs:enumeration value="StringFixedLength" />
+      <xs:enumeration value="Xml" />
+      <xs:enumeration value="DateTime2" />
+      <xs:enumeration value="DateTimeOffset" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="System.Data.IsolationLevel">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Unspecified" />
+      <xs:enumeration value="Chaos" />
+      <xs:enumeration value="ReadUncommitted" />
+      <xs:enumeration value="ReadCommitted" />
+      <xs:enumeration value="RepeatableRead" />
+      <xs:enumeration value="Serializable" />
+      <xs:enumeration value="Snapshot" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="NLog.Targets.DatabaseObjectPropertyInfo">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="culture" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="propertyType" type="xs:string" minOccurs="0" maxOccurs="1" default="System.String" />
+    </xs:choice>
+    <xs:attribute name="format" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Convert format of the property value</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="culture" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Culture used for parsing property string-value for type-conversion</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="layout" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Value to assign on the object-property</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Name for the object-property</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="propertyType" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Type of the object-property</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
   <xs:complexType name="NLog.Targets.DatabaseCommandInfo">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="commandType" minOccurs="0" maxOccurs="1" type="System.Data.CommandType" />
-      <xs:element name="connectionString" minOccurs="0" maxOccurs="1" type="Layout" />
-      <xs:element name="ignoreFailures" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+      <xs:element name="commandType" type="System.Data.CommandType" minOccurs="0" maxOccurs="1" default="Text" />
+      <xs:element name="connectionString" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="ignoreFailures" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
       <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.DatabaseParameterInfo" />
-      <xs:element name="text" minOccurs="0" maxOccurs="1" type="Layout" />
+      <xs:element name="text" type="Layout" minOccurs="0" maxOccurs="1" />
     </xs:choice>
     <xs:attribute name="commandType" type="System.Data.CommandType">
       <xs:annotation>
@@ -946,20 +1113,37 @@
   </xs:complexType>
   <xs:complexType name="NLog.Targets.DatabaseParameterInfo">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-      <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-      <xs:element name="precision" minOccurs="0" maxOccurs="1" type="xs:byte" />
-      <xs:element name="scale" minOccurs="0" maxOccurs="1" type="xs:byte" />
-      <xs:element name="size" minOccurs="0" maxOccurs="1" type="xs:integer" />
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="dbType" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="size" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+      <xs:element name="precision" type="xs:byte" minOccurs="0" maxOccurs="1" default="0" />
+      <xs:element name="scale" type="xs:byte" minOccurs="0" maxOccurs="1" default="0" />
+      <xs:element name="parameterType" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="defaultValue" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="format" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="culture" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="allowDbNull" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+      <xs:element name="dbTypeEnum" type="System.Data.DbType" minOccurs="0" maxOccurs="1" default="AnsiString" />
     </xs:choice>
-    <xs:attribute name="layout" type="SimpleLayoutAttribute">
-      <xs:annotation>
-        <xs:documentation>Layout that should be use to calcuate the value for the parameter.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
     <xs:attribute name="name" type="xs:string">
       <xs:annotation>
         <xs:documentation>Database parameter name.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="layout" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Layout used for rendering the database-parameter value.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="dbType" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Database parameter DbType.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="size" type="xs:integer">
+      <xs:annotation>
+        <xs:documentation>Database parameter size.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="precision" type="xs:byte">
@@ -972,9 +1156,34 @@
         <xs:documentation>Database parameter scale.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="size" type="xs:integer">
+    <xs:attribute name="parameterType" type="xs:string">
       <xs:annotation>
-        <xs:documentation>Database parameter size.</xs:documentation>
+        <xs:documentation>Type of the parameter.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="defaultValue" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Fallback value when result value is not available</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="format" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Convert format of the database parameter value.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="culture" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Culture used for parsing parameter string-value for type-conversion</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="allowDbNull" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Whether empty value should translate into DbNull. Requires database column to allow NULL values.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="dbTypeEnum" type="System.Data.DbType">
+      <xs:annotation>
+        <xs:documentation>Database parameter DbType (without reflection logic)</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
@@ -982,20 +1191,17 @@
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="header" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="footer" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="category" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="maxMessageSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="onOverflow" type="NLog.Targets.DebuggerTargetOverflowAction" minOccurs="0" maxOccurs="1" default="Split" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="layout" type="SimpleLayoutAttribute">
-          <xs:annotation>
-            <xs:documentation>Text to be rendered.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="header" type="SimpleLayoutAttribute">
@@ -1008,11 +1214,58 @@
             <xs:documentation>Footer.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+        <xs:attribute name="category" type="SimpleLayoutAttribute">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>The category of the message.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
+        <xs:attribute name="maxMessageSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum message size in number of characters. On limit breach then P:NLog.Targets.DebuggerTarget.OnOverflow action is activated.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onOverflow" type="NLog.Targets.DebuggerTargetOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken if the message is larger than P:NLog.Targets.DebuggerTarget.MaxMessageSize</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="NLog.Targets.DebuggerTargetOverflowAction">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None" />
+      <xs:enumeration value="Truncate" />
+      <xs:enumeration value="Split" />
+      <xs:enumeration value="Discard" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="DebugSystem">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="header" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Header.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="footer" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Footer.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -1020,9 +1273,8 @@
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
@@ -1032,32 +1284,143 @@
         <xs:attribute name="layout" type="SimpleLayoutAttribute">
           <xs:annotation>
             <xs:documentation>Layout used to format log messages.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:complexType name="DiagnosticListener">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="contextproperty" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.TargetPropertyWithContext" />
+          <xs:element name="includeCallSite" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeCallSiteStackTrace" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeGdc" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeScopeNested" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeScopeProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="excludeProperties" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="eventName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="levelName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sourceName" type="Layout" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
+        <xs:attribute name="includeCallSite" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to include call site (class and method name) in the T:NLog.LogEventInfo</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeCallSiteStackTrace" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to include source info (file name and line number) in the T:NLog.LogEventInfo</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeEventProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the P:NLog.LogEventInfo.Properties dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeGdc" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to include contents of the T:NLog.GlobalDiagnosticsContext dictionary</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopeNested" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.ScopeContext nested-state-stack.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopeProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.ScopeContext properties-dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="excludeProperties" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>List of property names to exclude when P:NLog.Targets.TargetWithContext.IncludeEventProperties is true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="eventName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Event Name for M:System.Diagnostics.DiagnosticSource.Write(System.String,System.Object)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="levelName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Value for Event Payload Level-Property</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sourceName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Source Name for T:System.Diagnostics.DiagnosticSource</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="NLog.Targets.TargetPropertyWithContext">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="defaultValue" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="includeEmptyValue" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+      <xs:element name="propertyType" type="xs:string" minOccurs="0" maxOccurs="1" default="System.String" />
+      <xs:element name="value" type="Layout" minOccurs="0" maxOccurs="1" />
+    </xs:choice>
+    <xs:attribute name="name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Name of the property.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="layout" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Layout used for rendering the property value.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="defaultValue" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Fallback value when result value is not available</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="includeEmptyValue" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Whether empty property value should be included in the output.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="propertyType" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Type of the property.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="value" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Layout used for rendering the property value. Alias for P:NLog.Targets.TargetPropertyWithContext.Layout</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
   <xs:complexType name="EventLog">
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="category" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="entryType" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="eventId" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="log" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="machineName" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="maxKilobytes" minOccurs="0" maxOccurs="1" type="xs:long" />
-          <xs:element name="maxMessageLength" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="source" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="onOverflow" minOccurs="0" maxOccurs="1" type="NLog.Targets.EventLogTargetOverflowAction" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="category" type="xs:integer" minOccurs="0" maxOccurs="1" />
+          <xs:element name="entryType" type="System.Diagnostics.EventLogEntryType" minOccurs="0" maxOccurs="1" />
+          <xs:element name="eventId" type="xs:integer" minOccurs="0" maxOccurs="1" />
+          <xs:element name="log" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="machineName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="maxKilobytes" type="xs:long" minOccurs="0" maxOccurs="1" />
+          <xs:element name="maxMessageLength" type="xs:integer" minOccurs="0" maxOccurs="1" default="30000" />
+          <xs:element name="source" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="onOverflow" type="NLog.Targets.EventLogTargetOverflowAction" minOccurs="0" maxOccurs="1" default="Truncate" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
@@ -1069,34 +1432,34 @@
             <xs:documentation>Layout used to format log messages.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="category" type="SimpleLayoutAttribute">
+        <xs:attribute name="category" type="xs:integer">
           <xs:annotation>
             <xs:documentation>Layout that renders event Category.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="entryType" type="SimpleLayoutAttribute">
+        <xs:attribute name="entryType" type="System.Diagnostics.EventLogEntryType">
           <xs:annotation>
-            <xs:documentation>Optional entrytype. When not set, or when not convertable to  then determined by </xs:documentation>
+            <xs:documentation>Optional entry type. When not set, or when not convertible to T:System.Diagnostics.EventLogEntryType then determined by T:NLog.LogLevel</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="eventId" type="SimpleLayoutAttribute">
+        <xs:attribute name="eventId" type="xs:integer">
           <xs:annotation>
             <xs:documentation>Layout that renders event ID.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="log" type="xs:string">
+        <xs:attribute name="log" type="SimpleLayoutAttribute">
           <xs:annotation>
             <xs:documentation>Name of the Event Log to write to. This can be System, Application or any user-defined name.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="machineName" type="xs:string">
+        <xs:attribute name="machineName" type="SimpleLayoutAttribute">
           <xs:annotation>
             <xs:documentation>Name of the machine on which Event Log service is running.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="maxKilobytes" type="xs:long">
           <xs:annotation>
-            <xs:documentation>Maximum Event log size in kilobytes. If null, the value won't be set. Default is 512 Kilobytes as specified by Eventlog API</xs:documentation>
+            <xs:documentation>Maximum Event log size in kilobytes.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="maxMessageLength" type="xs:integer">
@@ -1111,17 +1474,21 @@
         </xs:attribute>
         <xs:attribute name="onOverflow" type="NLog.Targets.EventLogTargetOverflowAction">
           <xs:annotation>
-            <xs:documentation>Action to take if the message is larger than the  option.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Action to take if the message is larger than the P:NLog.Targets.EventLogTarget.MaxMessageLength option.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:simpleType name="System.Diagnostics.EventLogEntryType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Error" />
+      <xs:enumeration value="Warning" />
+      <xs:enumeration value="Information" />
+      <xs:enumeration value="SuccessAudit" />
+      <xs:enumeration value="FailureAudit" />
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="NLog.Targets.EventLogTargetOverflowAction">
     <xs:restriction base="xs:string">
       <xs:enumeration value="Truncate" />
@@ -1133,9 +1500,9 @@
     <xs:complexContent>
       <xs:extension base="CompoundTargetBase">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="returnToFirstOnSuccess" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="returnToFirstOnSuccess" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="enableBatchWrite" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
@@ -1147,9 +1514,9 @@
             <xs:documentation>Indicates whether to return to the first target after any successful write.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+        <xs:attribute name="enableBatchWrite" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Whether to enable batching, but fallback will be handled individually</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -1159,55 +1526,43 @@
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="header" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="footer" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="encoding" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="lineEnding" minOccurs="0" maxOccurs="1" type="LineEndingMode" />
-          <xs:element name="enableArchiveFileCompression" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="archiveNumbering" minOccurs="0" maxOccurs="1" type="NLog.Targets.ArchiveNumberingMode" />
-          <xs:element name="archiveFileName" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="archiveFileKind" minOccurs="0" maxOccurs="1" type="NLog.Targets.FilePathKind" />
-          <xs:element name="archiveEvery" minOccurs="0" maxOccurs="1" type="NLog.Targets.FileArchivePeriod" />
-          <xs:element name="archiveAboveSize" minOccurs="0" maxOccurs="1" type="xs:long" />
-          <xs:element name="maxArchiveFiles" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="writeFooterOnArchivingOnly" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="maxLogFilenames" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="fileNameKind" minOccurs="0" maxOccurs="1" type="NLog.Targets.FilePathKind" />
-          <xs:element name="forceManaged" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="forceMutexConcurrentWrites" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="replaceFileContentsOnEachWrite" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="writeBom" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="enableFileDelete" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="fileName" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="archiveDateFormat" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="archiveOldFileOnStartup" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="cleanupFileName" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="createDirs" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="deleteOldFileOnStartup" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="fileAttributes" minOccurs="0" maxOccurs="1" type="NLog.Targets.Win32FileAttributes" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="networkWrites" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="openFileCacheTimeout" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="openFileCacheSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="keepFileOpen" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="discardAll" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="concurrentWrites" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="concurrentWriteAttempts" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="concurrentWriteAttemptDelay" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="bufferSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="openFileFlushTimeout" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="autoFlush" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="fileName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="archiveAboveSize" type="xs:long" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="archiveEvery" type="NLog.Targets.FileArchivePeriod" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="archiveFileName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="archiveOldFileOnStartup" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="archiveSuffixFormat" type="xs:string" minOccurs="0" maxOccurs="1" default="_{0:00}" />
+          <xs:element name="maxArchiveDays" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="maxArchiveFiles" type="xs:integer" minOccurs="0" maxOccurs="1" default="-1" />
+          <xs:element name="writeFooterOnArchivingOnly" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="writeHeaderWhenInitialFileNotEmpty" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="encoding" type="xs:string" minOccurs="0" maxOccurs="1" default="utf-8" />
+          <xs:element name="createDirs" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="deleteOldFileOnStartup" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="enableFileDelete" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="writeBom" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="discardAll" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="lineEnding" type="LineEndingMode" minOccurs="0" maxOccurs="1" />
+          <xs:element name="replaceFileContentsOnEachWrite" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="openFileCacheSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="5" />
+          <xs:element name="autoFlush" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="bufferSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="32768" />
+          <xs:element name="openFileCacheTimeout" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="openFileFlushTimeout" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="keepFileOpen" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="layout" type="SimpleLayoutAttribute">
+        <xs:attribute name="fileName" type="SimpleLayoutAttribute">
           <xs:annotation>
-            <xs:documentation>Text to be rendered.</xs:documentation>
+            <xs:documentation>Name of the file to write to.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="header" type="SimpleLayoutAttribute">
@@ -1220,49 +1575,39 @@
             <xs:documentation>Footer.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="encoding" type="xs:string">
+        <xs:attribute name="archiveAboveSize" type="xs:long">
           <xs:annotation>
-            <xs:documentation>File encoding.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="lineEnding" type="LineEndingMode">
-          <xs:annotation>
-            <xs:documentation>Line ending mode.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="enableArchiveFileCompression" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to compress archive files into the zip archive format.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="archiveNumbering" type="NLog.Targets.ArchiveNumberingMode">
-          <xs:annotation>
-            <xs:documentation>Way file archives are numbered.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="archiveFileName" type="SimpleLayoutAttribute">
-          <xs:annotation>
-            <xs:documentation>Name of the file to be used for an archive.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="archiveFileKind" type="NLog.Targets.FilePathKind">
-          <xs:annotation>
-            <xs:documentation>Is the  an absolute or relative path?</xs:documentation>
+            <xs:documentation>Size in bytes above which log files will be automatically archived. Zero or negative means disabled.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="archiveEvery" type="NLog.Targets.FileArchivePeriod">
           <xs:annotation>
-            <xs:documentation>Indicates whether to automatically archive log files every time the specified time passes.</xs:documentation>
+            <xs:documentation>Indicates whether to trigger archive operation based on time-period, by moving active-file to file-path specified by P:NLog.Targets.FileTarget.ArchiveFileName</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="archiveAboveSize" type="xs:long">
+        <xs:attribute name="archiveFileName" type="SimpleLayoutAttribute">
           <xs:annotation>
-            <xs:documentation>Size in bytes above which log files will be automatically archived. Warning: combining this with  isn't supported. We cannot create multiple archive files, if they should have the same name. Choose: </xs:documentation>
+            <xs:documentation>Legacy archive logic where file-archive-logic moves active file to path specified by P:NLog.Targets.FileTarget.ArchiveFileName, and then recreates the active file. Use P:NLog.Targets.FileTarget.ArchiveSuffixFormat to control suffix format, instead of now obsolete token {#}</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="archiveOldFileOnStartup" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether any existing log-file should be archived on startup.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="archiveSuffixFormat" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Format-string to convert archive sequence-number by using string.Format</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxArchiveDays" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum days of archive files that should be kept. Zero or negative means disabled.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="maxArchiveFiles" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>Maximum number of archive files that should be kept.</xs:documentation>
+            <xs:documentation>Maximum number of archive files that should be kept. Negative means disabled.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="writeFooterOnArchivingOnly" type="xs:boolean">
@@ -1270,59 +1615,15 @@
             <xs:documentation>Indicates whether the footer should be written only when the file is archived.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="maxLogFilenames" type="xs:integer">
+        <xs:attribute name="writeHeaderWhenInitialFileNotEmpty" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Maximum number of log filenames that should be stored as existing.</xs:documentation>
+            <xs:documentation>Whether to write the Header on initial creation of file appender, even if the file is not empty. Default value is false, which means only write header when initial file is empty (Ex. ensures valid CSV files)</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="fileNameKind" type="NLog.Targets.FilePathKind">
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
+        <xs:attribute name="encoding" type="xs:string">
           <xs:annotation>
-            <xs:documentation>Is the  an absolute or relative path?</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="forceManaged" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Gets or set a value indicating whether a managed file stream is forced, instead of using the native implementation.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="forceMutexConcurrentWrites" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Value indicationg whether file creation calls should be synchronized by a system global mutex.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="replaceFileContentsOnEachWrite" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to replace file contents on each write instead of appending log message at the end.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="writeBom" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to write BOM (byte order mark) in created files</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="enableFileDelete" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to enable log file(s) to be deleted.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="fileName" type="SimpleLayoutAttribute">
-          <xs:annotation>
-            <xs:documentation>Name of the file to write to.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="archiveDateFormat" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>Value specifying the date format to use when archiving files.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="archiveOldFileOnStartup" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to archive old log file on startup.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="cleanupFileName" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Cleanup invalid values in a filename, e.g. slashes in a filename. If set to true, this can impact the performance of massive writes. If set to false, nothing gets written when the filename is wrong.</xs:documentation>
+            <xs:documentation>File encoding.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="createDirs" type="xs:boolean">
@@ -1335,34 +1636,14 @@
             <xs:documentation>Indicates whether to delete old log file on startup.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="fileAttributes" type="NLog.Targets.Win32FileAttributes">
+        <xs:attribute name="enableFileDelete" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>File attributes (Windows only).</xs:documentation>
+            <xs:documentation>Indicates whether to enable log file(s) to be deleted.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+        <xs:attribute name="writeBom" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="networkWrites" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether concurrent writes to the log file by multiple processes on different network hosts.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="openFileCacheTimeout" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Maximum number of seconds that files are kept open. If this number is negative the files are not automatically closed after a period of inactivity.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="openFileCacheSize" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Number of files to be kept open. Setting this to a higher value may improve performance in a situation where a single File target is writing to many files (such as splitting by level or by logger).</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="keepFileOpen" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to keep log file open instead of opening and closing it on each logging event.</xs:documentation>
+            <xs:documentation>Indicates whether to write BOM (byte order mark) in created files.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="discardAll" type="xs:boolean">
@@ -1370,29 +1651,19 @@
             <xs:documentation>Whether or not this target should just discard all data that its asked to write. Mostly used for when testing NLog Stack except final write</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="concurrentWrites" type="xs:boolean">
+        <xs:attribute name="lineEnding" type="LineEndingMode">
           <xs:annotation>
-            <xs:documentation>Indicates whether concurrent writes to the log file by multiple processes on the same host.</xs:documentation>
+            <xs:documentation>Line ending mode.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="concurrentWriteAttempts" type="xs:integer">
+        <xs:attribute name="replaceFileContentsOnEachWrite" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Number of times the write is appended on the file before NLog discards the log message.</xs:documentation>
+            <xs:documentation>Indicates whether to replace file contents on each write instead of appending log message at the end.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="concurrentWriteAttemptDelay" type="xs:integer">
+        <xs:attribute name="openFileCacheSize" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>Delay in milliseconds to wait before attempting to write to the file again.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="bufferSize" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Log file buffer size in bytes.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="openFileFlushTimeout" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Maximum number of seconds before open files are flushed. If this number is negative or zero the files are not flushed by timer.</xs:documentation>
+            <xs:documentation>Maximum number of files to be kept open.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="autoFlush" type="xs:boolean">
@@ -1400,68 +1671,36 @@
             <xs:documentation>Indicates whether to automatically flush the file buffers after each log message.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="bufferSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Log file buffer size in bytes.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="openFileCacheTimeout" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum number of seconds that files are kept open. Zero or negative means disabled.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="openFileFlushTimeout" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum number of seconds before open files are flushed. Zero or negative means disabled.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepFileOpen" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to keep log file open instead of opening and closing it on each logging event.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:simpleType name="NLog.Targets.ArchiveNumberingMode">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="Sequence" />
-      <xs:enumeration value="Rolling" />
-      <xs:enumeration value="Date" />
-      <xs:enumeration value="DateAndSequence" />
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:simpleType name="NLog.Targets.FilePathKind">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="Unknown" />
-      <xs:enumeration value="Relative" />
-      <xs:enumeration value="Absolute" />
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:simpleType name="NLog.Targets.FileArchivePeriod">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="None" />
-      <xs:enumeration value="Year" />
-      <xs:enumeration value="Month" />
-      <xs:enumeration value="Day" />
-      <xs:enumeration value="Hour" />
-      <xs:enumeration value="Minute" />
-      <xs:enumeration value="Sunday" />
-      <xs:enumeration value="Monday" />
-      <xs:enumeration value="Tuesday" />
-      <xs:enumeration value="Wednesday" />
-      <xs:enumeration value="Thursday" />
-      <xs:enumeration value="Friday" />
-      <xs:enumeration value="Saturday" />
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:simpleType name="NLog.Targets.Win32FileAttributes">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="ReadOnly" />
-      <xs:enumeration value="Hidden" />
-      <xs:enumeration value="System" />
-      <xs:enumeration value="Archive" />
-      <xs:enumeration value="Device" />
-      <xs:enumeration value="Normal" />
-      <xs:enumeration value="Temporary" />
-      <xs:enumeration value="SparseFile" />
-      <xs:enumeration value="ReparsePoint" />
-      <xs:enumeration value="Compressed" />
-      <xs:enumeration value="NotContentIndexed" />
-      <xs:enumeration value="Encrypted" />
-      <xs:enumeration value="WriteThrough" />
-      <xs:enumeration value="NoBuffering" />
-      <xs:enumeration value="DeleteOnClose" />
-      <xs:enumeration value="PosixSemantics" />
-    </xs:restriction>
-  </xs:simpleType>
   <xs:complexType name="FilteringWrapper">
     <xs:complexContent>
       <xs:extension base="WrapperTargetBase">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="condition" minOccurs="0" maxOccurs="1" type="Condition" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="condition" type="Condition" minOccurs="0" maxOccurs="1" />
+          <xs:element name="filter" type="Filter" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
@@ -1473,34 +1712,476 @@
             <xs:documentation>Condition expression. Log events who meet this condition will be forwarded to the wrapped target.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="ImpersonatingWrapper">
+  <xs:complexType name="FormControl">
     <xs:complexContent>
-      <xs:extension base="WrapperTargetBase">
+      <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="domain" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="impersonationLevel" minOccurs="0" maxOccurs="1" type="NLog.Targets.Wrappers.SecurityImpersonationLevel" />
-          <xs:element name="logOnProvider" minOccurs="0" maxOccurs="1" type="NLog.Targets.Wrappers.LogOnProviderType" />
-          <xs:element name="logOnType" minOccurs="0" maxOccurs="1" type="NLog.Targets.Wrappers.SecurityLogOnType" />
-          <xs:element name="password" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="revertToSelf" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="userName" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="append" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="controlName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="formName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="reverseOrder" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="domain" type="xs:string">
+        <xs:attribute name="layout" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Layout used to format log messages.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="append" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether log text should be appended to the text of the control instead of overwriting it.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="controlName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Name of control to which NLog will log write log text.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="formName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Name of the Form on which the control is located.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="reverseOrder" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether new log entry are added to the start or the end of the control</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="Gelf">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslCertificatePassword" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslCertificateFile" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslProtocols" type="System.Security.Authentication.SslProtocols" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="sendTimeoutSeconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="100" />
+          <xs:element name="onOverflow" type="NLog.Targets.NetworkTargetOverflowAction" minOccurs="0" maxOccurs="1" default="Split" />
+          <xs:element name="onConnectionOverflow" type="NLog.Targets.NetworkTargetConnectionsOverflowAction" minOccurs="0" maxOccurs="1" default="Discard" />
+          <xs:element name="onQueueOverflow" type="NLog.Targets.NetworkTargetQueueOverflowAction" minOccurs="0" maxOccurs="1" default="Discard" />
+          <xs:element name="maxConnections" type="xs:integer" minOccurs="0" maxOccurs="1" default="100" />
+          <xs:element name="keepConnection" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="keepAliveTimeSeconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="connectionCacheSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="5" />
+          <xs:element name="address" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="maxQueueSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="10000" />
+          <xs:element name="gelfShortMessage" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="noDelay" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="includeScopeProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="gelfHostName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="compress" type="NLog.Targets.NetworkTargetCompressionType" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="GelfField" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.TargetPropertyWithContext" />
+          <xs:element name="gelfFacility" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="excludeEmptyProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="compressMinBytes" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="gelfFullMessage" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="maxMessageSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="65000" />
+          <xs:element name="encoding" type="xs:string" minOccurs="0" maxOccurs="1" default="utf-8" />
+          <xs:element name="lineEnding" type="LineEndingMode" minOccurs="0" maxOccurs="1" />
+          <xs:element name="newLine" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sslCertificatePassword" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Password for the custom SSL certificate specified by P:NLog.Targets.NetworkTarget.SslCertificateFile</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sslCertificateFile" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>File path to custom SSL certificate for TCP Socket SSL connections</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sslProtocols" type="System.Security.Authentication.SslProtocols">
+          <xs:annotation>
+            <xs:documentation>SSL/TLS protocols. Default no SSL/TLS is used. Currently only implemented for TCP.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sendTimeoutSeconds" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>The number of seconds a TCP socket send-operation will block before timeout error. Default = 100 secs (0 = wait forever when network cable unplugged and tcp-buffer becomes full).</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onOverflow" type="NLog.Targets.NetworkTargetOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken if the message is larger than P:NLog.Targets.NetworkTarget.MaxMessageSize</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onConnectionOverflow" type="NLog.Targets.NetworkTargetConnectionsOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken, when more connections than P:NLog.Targets.NetworkTarget.MaxConnections.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onQueueOverflow" type="NLog.Targets.NetworkTargetQueueOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken, when more pending messages than P:NLog.Targets.NetworkTarget.MaxQueueSize.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxConnections" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum simultaneous connections. Requires P:NLog.Targets.NetworkTarget.KeepConnection = false</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepConnection" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to keep connection open whenever possible.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepAliveTimeSeconds" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>The number of seconds a connection will remain idle before the first keep-alive probe is sent</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="connectionCacheSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Size of the connection cache (number of connections which are kept alive). Requires P:NLog.Targets.NetworkTarget.KeepConnection = true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="address" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Network destination address.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxQueueSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum queue size for a single connection. Requires P:NLog.Targets.NetworkTarget.KeepConnection = true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="gelfShortMessage" type="SimpleLayoutAttribute" />
+        <xs:attribute name="noDelay" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to disable the delayed ACK timer, and avoid delay of 200 ms.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
+        <xs:attribute name="includeScopeProperties" type="xs:boolean" />
+        <xs:attribute name="includeEventProperties" type="xs:boolean" />
+        <xs:attribute name="gelfHostName" type="SimpleLayoutAttribute" />
+        <xs:attribute name="compress" type="NLog.Targets.NetworkTargetCompressionType">
+          <xs:annotation>
+            <xs:documentation>Type of compression for protocol payload. Useful for UDP where datagram max-size is 8192 bytes.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="gelfFacility" type="SimpleLayoutAttribute" />
+        <xs:attribute name="excludeEmptyProperties" type="xs:boolean" />
+        <xs:attribute name="compressMinBytes" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Skip compression when protocol payload is below limit to reduce overhead in cpu-usage and additional headers</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="gelfFullMessage" type="SimpleLayoutAttribute" />
+        <xs:attribute name="maxMessageSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum message size in bytes. On limit breach then P:NLog.Targets.NetworkTarget.OnOverflow action is activated.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="encoding" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Encoding to be used.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="lineEnding" type="LineEndingMode">
+          <xs:annotation>
+            <xs:documentation>End of line value if a newline is appended at the end of log message P:NLog.Targets.NetworkTarget.NewLine.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="newLine" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to append newline at the end of log message.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="System.Security.Authentication.SslProtocols">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None" />
+      <xs:enumeration value="Ssl2" />
+      <xs:enumeration value="Ssl3" />
+      <xs:enumeration value="Tls" />
+      <xs:enumeration value="Tls11" />
+      <xs:enumeration value="Tls12" />
+      <xs:enumeration value="Tls13" />
+      <xs:enumeration value="Default" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="NLog.Targets.NetworkTargetOverflowAction">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Error" />
+      <xs:enumeration value="Split" />
+      <xs:enumeration value="Discard" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="NLog.Targets.NetworkTargetConnectionsOverflowAction">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Grow" />
+      <xs:enumeration value="AllowNewConnnection" />
+      <xs:enumeration value="Discard" />
+      <xs:enumeration value="DiscardMessage" />
+      <xs:enumeration value="Block" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="NLog.Targets.NetworkTargetQueueOverflowAction">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Grow" />
+      <xs:enumeration value="Discard" />
+      <xs:enumeration value="Block" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="NLog.Targets.NetworkTargetCompressionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None" />
+      <xs:enumeration value="GZip" />
+      <xs:enumeration value="GZipFast" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="GroupByWrapper">
+    <xs:complexContent>
+      <xs:extension base="WrapperTargetBase">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="key" type="Layout" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="key" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Identifier to perform group-by</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="GZipFile">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="fileName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="writeHeaderWhenInitialFileNotEmpty" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="writeFooterOnArchivingOnly" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="maxArchiveDays" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="archiveSuffixFormat" type="xs:string" minOccurs="0" maxOccurs="1" default="_{0:00}" />
+          <xs:element name="maxArchiveFiles" type="xs:integer" minOccurs="0" maxOccurs="1" default="-1" />
+          <xs:element name="archiveFileName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="archiveEvery" type="NLog.Targets.FileArchivePeriod" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="archiveAboveSize" type="xs:long" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="archiveOldFileOnStartup" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="enableArchiveFileCompression" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="compressionLevel" type="System.IO.Compression.CompressionLevel" minOccurs="0" maxOccurs="1" default="Fastest" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="discardAll" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="writeBom" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="enableFileDelete" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="deleteOldFileOnStartup" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="createDirs" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="encoding" type="xs:string" minOccurs="0" maxOccurs="1" default="utf-8" />
+          <xs:element name="replaceFileContentsOnEachWrite" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="lineEnding" type="LineEndingMode" minOccurs="0" maxOccurs="1" />
+          <xs:element name="openFileCacheTimeout" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="bufferSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="32768" />
+          <xs:element name="autoFlush" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="keepFileOpen" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="openFileFlushTimeout" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="openFileCacheSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="5" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fileName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Name of the file to write to.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="header" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Header.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="footer" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Footer.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="writeHeaderWhenInitialFileNotEmpty" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to write the Header on initial creation of file appender, even if the file is not empty. Default value is false, which means only write header when initial file is empty (Ex. ensures valid CSV files)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="writeFooterOnArchivingOnly" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether the footer should be written only when the file is archived.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxArchiveDays" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum days of archive files that should be kept. Zero or negative means disabled.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="archiveSuffixFormat" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Format-string to convert archive sequence-number by using string.Format</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxArchiveFiles" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum number of archive files that should be kept. Negative means disabled.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="archiveFileName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Legacy archive logic where file-archive-logic moves active file to path specified by P:NLog.Targets.FileTarget.ArchiveFileName, and then recreates the active file. Use P:NLog.Targets.FileTarget.ArchiveSuffixFormat to control suffix format, instead of now obsolete token {#}</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="archiveEvery" type="NLog.Targets.FileArchivePeriod">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to trigger archive operation based on time-period, by moving active-file to file-path specified by P:NLog.Targets.FileTarget.ArchiveFileName</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="archiveAboveSize" type="xs:long">
+          <xs:annotation>
+            <xs:documentation>Size in bytes above which log files will be automatically archived. Zero or negative means disabled.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="archiveOldFileOnStartup" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether any existing log-file should be archived on startup.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enableArchiveFileCompression" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to enable file-compression using T:System.IO.Compression.GZipStream</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="compressionLevel" type="System.IO.Compression.CompressionLevel">
+          <xs:annotation>
+            <xs:documentation>Whether to emphasize Fastest-speed or Optimal-compression</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
+        <xs:attribute name="discardAll" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether or not this target should just discard all data that its asked to write. Mostly used for when testing NLog Stack except final write</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="writeBom" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to write BOM (byte order mark) in created files.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enableFileDelete" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to enable log file(s) to be deleted.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="deleteOldFileOnStartup" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to delete old log file on startup.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="createDirs" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to create directories if they do not exist.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="encoding" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>File encoding.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="replaceFileContentsOnEachWrite" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to replace file contents on each write instead of appending log message at the end.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="lineEnding" type="LineEndingMode">
+          <xs:annotation>
+            <xs:documentation>Line ending mode.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="openFileCacheTimeout" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum number of seconds that files are kept open. Zero or negative means disabled.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="bufferSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Log file buffer size in bytes.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="autoFlush" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to automatically flush the file buffers after each log message.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepFileOpen" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to keep log file open instead of opening and closing it on each logging event.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="openFileFlushTimeout" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum number of seconds before open files are flushed. Zero or negative means disabled.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="openFileCacheSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum number of files to be kept open.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="System.IO.Compression.CompressionLevel">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Optimal" />
+      <xs:enumeration value="Fastest" />
+      <xs:enumeration value="NoCompression" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="ImpersonatingWrapper">
+    <xs:complexContent>
+      <xs:extension base="WrapperTargetBase">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="domain" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="impersonationLevel" type="NLog.Targets.Wrappers.SecurityImpersonationLevel" minOccurs="0" maxOccurs="1" default="Impersonation" />
+          <xs:element name="logOnProvider" type="NLog.Targets.Wrappers.LogOnProviderType" minOccurs="0" maxOccurs="1" default="Default" />
+          <xs:element name="logOnType" type="NLog.Targets.Wrappers.SecurityLogOnType" minOccurs="0" maxOccurs="1" default="Interactive" />
+          <xs:element name="password" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="revertToSelf" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="userName" type="Layout" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="domain" type="SimpleLayoutAttribute">
           <xs:annotation>
             <xs:documentation>Windows domain name to change context to.</xs:documentation>
           </xs:annotation>
@@ -1520,7 +2201,7 @@
             <xs:documentation>Logon Type.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="password" type="xs:string">
+        <xs:attribute name="password" type="SimpleLayoutAttribute">
           <xs:annotation>
             <xs:documentation>User account password.</xs:documentation>
           </xs:annotation>
@@ -1530,14 +2211,9 @@
             <xs:documentation>Indicates whether to revert to the credentials of the process instead of impersonating another user.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="userName" type="xs:string">
+        <xs:attribute name="userName" type="SimpleLayoutAttribute">
           <xs:annotation>
             <xs:documentation>Username to change context to.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -1570,54 +2246,276 @@
     <xs:complexContent>
       <xs:extension base="WrapperTargetBase">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="interval" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="messageLimit" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="interval" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="messageLimit" type="xs:integer" minOccurs="0" maxOccurs="1" default="1000" />
         </xs:choice>
-        <xs:attribute name="interval" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>Interval in which messages will be written up to the  number of messages.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="messageLimit" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Maximum allowed number of messages written per .</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+        <xs:attribute name="interval" type="xs:string">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Interval in which messages will be written up to the P:NLog.Targets.Wrappers.LimitingTargetWrapper.MessageLimit number of messages.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="messageLimit" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum allowed number of messages written per P:NLog.Targets.Wrappers.LimitingTargetWrapper.Interval.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="LogReceiverService">
+  <xs:complexType name="Log4JXml">
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="endpointAddress" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="endpointConfigurationName" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="useOneWayContract" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="clientId" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="includeEventProperties" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.MethodCallParameter" />
-          <xs:element name="useBinaryEncoding" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="scopeNestedSeparator" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.Log4JXmlEventParameter" />
+          <xs:element name="ndcItemSeparator" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="loggerName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="includeScopeProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeScopeNested" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeSourceInfo" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeCallSite" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="formattedMessage" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="appInfo" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="includeNdc" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="onQueueOverflow" type="NLog.Targets.NetworkTargetQueueOverflowAction" minOccurs="0" maxOccurs="1" default="Discard" />
+          <xs:element name="sslCertificatePassword" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslCertificateFile" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslProtocols" type="System.Security.Authentication.SslProtocols" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="sendTimeoutSeconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="100" />
+          <xs:element name="onOverflow" type="NLog.Targets.NetworkTargetOverflowAction" minOccurs="0" maxOccurs="1" default="Split" />
+          <xs:element name="keepAliveTimeSeconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="maxQueueSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="10000" />
+          <xs:element name="maxConnections" type="xs:integer" minOccurs="0" maxOccurs="1" default="100" />
+          <xs:element name="keepConnection" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="connectionCacheSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="5" />
+          <xs:element name="address" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="onConnectionOverflow" type="NLog.Targets.NetworkTargetConnectionsOverflowAction" minOccurs="0" maxOccurs="1" default="Discard" />
+          <xs:element name="compress" type="NLog.Targets.NetworkTargetCompressionType" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="compressMinBytes" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="noDelay" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="maxMessageSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="65000" />
+          <xs:element name="encoding" type="xs:string" minOccurs="0" maxOccurs="1" default="utf-8" />
+          <xs:element name="lineEnding" type="LineEndingMode" minOccurs="0" maxOccurs="1" />
+          <xs:element name="newLine" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="endpointAddress" type="xs:string">
+        <xs:attribute name="scopeNestedSeparator" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Separator for T:NLog.ScopeContext operation-states-stack.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="ndcItemSeparator" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Stack separator for log4j:NDC in output from T:NLog.ScopeContext nested context.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="loggerName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Log4j:event logger-xml-attribute. Default: ${logger}</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopeProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.ScopeContext properties-dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopeNested" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include log4j:NDC in output from T:NLog.ScopeContext nested context.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeSourceInfo" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to include source info (file name and line number) in the information sent over the network.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeEventProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to include all properties from the log events</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeCallSite" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to include call site (class and method name) in the information sent over the network.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="formattedMessage" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Log4j:event message-xml-element. Default: ${message}</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="appInfo" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Log4j:event log4japp-xml-element. By default it's the friendly name of the current AppDomain.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Instance of T:NLog.Layouts.Log4JXmlEventLayout that is used to format log messages.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeNdc" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include log4j:NDC in output from T:NLog.ScopeContext nested context.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onQueueOverflow" type="NLog.Targets.NetworkTargetQueueOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken, when more pending messages than P:NLog.Targets.NetworkTarget.MaxQueueSize.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sslCertificatePassword" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Password for the custom SSL certificate specified by P:NLog.Targets.NetworkTarget.SslCertificateFile</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sslCertificateFile" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>File path to custom SSL certificate for TCP Socket SSL connections</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sslProtocols" type="System.Security.Authentication.SslProtocols">
+          <xs:annotation>
+            <xs:documentation>SSL/TLS protocols. Default no SSL/TLS is used. Currently only implemented for TCP.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sendTimeoutSeconds" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>The number of seconds a TCP socket send-operation will block before timeout error. Default = 100 secs (0 = wait forever when network cable unplugged and tcp-buffer becomes full).</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onOverflow" type="NLog.Targets.NetworkTargetOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken if the message is larger than P:NLog.Targets.NetworkTarget.MaxMessageSize</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepAliveTimeSeconds" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>The number of seconds a connection will remain idle before the first keep-alive probe is sent</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxQueueSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum queue size for a single connection. Requires P:NLog.Targets.NetworkTarget.KeepConnection = true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxConnections" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum simultaneous connections. Requires P:NLog.Targets.NetworkTarget.KeepConnection = false</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepConnection" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to keep connection open whenever possible.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="connectionCacheSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Size of the connection cache (number of connections which are kept alive). Requires P:NLog.Targets.NetworkTarget.KeepConnection = true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="address" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Network destination address.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onConnectionOverflow" type="NLog.Targets.NetworkTargetConnectionsOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken, when more connections than P:NLog.Targets.NetworkTarget.MaxConnections.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="compress" type="NLog.Targets.NetworkTargetCompressionType">
+          <xs:annotation>
+            <xs:documentation>Type of compression for protocol payload. Useful for UDP where datagram max-size is 8192 bytes.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="compressMinBytes" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Skip compression when protocol payload is below limit to reduce overhead in cpu-usage and additional headers</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="noDelay" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to disable the delayed ACK timer, and avoid delay of 200 ms.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxMessageSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum message size in bytes. On limit breach then P:NLog.Targets.NetworkTarget.OnOverflow action is activated.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="encoding" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Encoding to be used.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="lineEnding" type="LineEndingMode">
+          <xs:annotation>
+            <xs:documentation>End of line value if a newline is appended at the end of log message P:NLog.Targets.NetworkTarget.NewLine.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="newLine" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to append newline at the end of log message.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="NLog.Layouts.Log4JXmlEventParameter">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="includeEmptyValue" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+    </xs:choice>
+    <xs:attribute name="name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Log4j:data property-name.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="layout" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Layout used for rendering the log4j:data property-value.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="includeEmptyValue" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Whether empty property-value should be included in the output. Default = false</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="LogReceiverService">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="endpointAddress" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="endpointConfigurationName" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="useOneWayContract" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="clientId" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.MethodCallParameter" />
+          <xs:element name="useBinaryEncoding" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="endpointAddress" type="SimpleLayoutAttribute">
           <xs:annotation>
             <xs:documentation>Endpoint address.</xs:documentation>
           </xs:annotation>
@@ -1647,29 +2545,29 @@
             <xs:documentation>Indicates whether to use binary message encoding.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
   <xs:complexType name="NLog.Targets.MethodCallParameter">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-      <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-      <xs:element name="parameterType" minOccurs="0" maxOccurs="1" type="xs:string" />
-      <xs:element name="type" minOccurs="0" maxOccurs="1" type="xs:string" />
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="defaultValue" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="parameterType" type="xs:string" minOccurs="0" maxOccurs="1" default="System.String" />
     </xs:choice>
-    <xs:attribute name="layout" type="SimpleLayoutAttribute">
-      <xs:annotation>
-        <xs:documentation>Layout that should be use to calculate the value for the parameter.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
     <xs:attribute name="name" type="xs:string">
       <xs:annotation>
         <xs:documentation>Name of the parameter.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="layout" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Layout used for rendering the method-parameter value.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="defaultValue" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Fallback value when result value is not available</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="parameterType" type="xs:string">
@@ -1677,51 +2575,44 @@
         <xs:documentation>Type of the parameter.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="type" type="xs:string">
-      <xs:annotation>
-        <xs:documentation>Type of the parameter. Obsolete alias for </xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
   </xs:complexType>
   <xs:complexType name="Mail">
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="header" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="footer" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="replaceNewlineWithBrTagInHtml" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="priority" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="encoding" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="bcc" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="cc" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="addNewLines" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="html" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="from" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="body" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="subject" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="to" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="timeout" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="smtpServer" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="smtpAuthentication" minOccurs="0" maxOccurs="1" type="NLog.Targets.SmtpAuthenticationMode" />
-          <xs:element name="smtpUserName" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="smtpPassword" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="enableSsl" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="smtpPort" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="useSystemNetMailSettings" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="pickupDirectoryLocation" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="deliveryMethod" minOccurs="0" maxOccurs="1" type="System.Net.Mail.SmtpDeliveryMethod" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="priority" type="System.Net.Mail.MailPriority" minOccurs="0" maxOccurs="1" default="Normal" />
+          <xs:element name="mailheader" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.MethodCallParameter" />
+          <xs:element name="addNewLines" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="encoding" type="xs:string" minOccurs="0" maxOccurs="1" default="utf-8" />
+          <xs:element name="bcc" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="replaceNewlineWithBrTagInHtml" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="to" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="html" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="from" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="body" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="subject" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="cc" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="pickupDirectoryLocation" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="timeout" type="xs:integer" minOccurs="0" maxOccurs="1" default="10000" />
+          <xs:element name="skipCertificateValidation" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="smtpPort" type="xs:integer" minOccurs="0" maxOccurs="1" default="25" />
+          <xs:element name="secureSocketOption" type="MailKit.Security.SecureSocketOptions" minOccurs="0" maxOccurs="1" default="StartTlsWhenAvailable" />
+          <xs:element name="smtpPassword" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="enableSsl" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="smtpUserName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="smtpAuthentication" type="NLog.Targets.SmtpAuthenticationMode" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="smtpServer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="useSystemNetMailSettings" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="requireTLS" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="deliveryMethod" type="System.Net.Mail.SmtpDeliveryMethod" minOccurs="0" maxOccurs="1" default="Network" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="layout" type="SimpleLayoutAttribute">
-          <xs:annotation>
-            <xs:documentation>Text to be rendered.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="header" type="SimpleLayoutAttribute">
@@ -1734,14 +2625,14 @@
             <xs:documentation>Footer.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="replaceNewlineWithBrTagInHtml" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether NewLine characters in the body should be replaced with  tags.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="priority" type="SimpleLayoutAttribute">
+        <xs:attribute name="priority" type="System.Net.Mail.MailPriority">
           <xs:annotation>
             <xs:documentation>Priority used for sending mails.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="addNewLines" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to add new lines between log entries.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="encoding" type="xs:string">
@@ -1754,14 +2645,14 @@
             <xs:documentation>BCC email addresses separated by semicolons (e.g. john@domain.com;jane@domain.com).</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="cc" type="SimpleLayoutAttribute">
+        <xs:attribute name="replaceNewlineWithBrTagInHtml" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>CC email addresses separated by semicolons (e.g. john@domain.com;jane@domain.com).</xs:documentation>
+            <xs:documentation>Indicates whether NewLine characters in the body should be replaced with  tags.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="addNewLines" type="xs:boolean">
+        <xs:attribute name="to" type="SimpleLayoutAttribute">
           <xs:annotation>
-            <xs:documentation>Indicates whether to add new lines between log entries.</xs:documentation>
+            <xs:documentation>Recipients' email addresses separated by semicolons (e.g. john@domain.com;jane@domain.com).</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="html" type="xs:boolean">
@@ -1784,14 +2675,15 @@
             <xs:documentation>Mail subject.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="to" type="SimpleLayoutAttribute">
+        <xs:attribute name="cc" type="SimpleLayoutAttribute">
           <xs:annotation>
-            <xs:documentation>Recipients' email addresses separated by semicolons (e.g. john@domain.com;jane@domain.com).</xs:documentation>
+            <xs:documentation>CC email addresses separated by semicolons (e.g. john@domain.com;jane@domain.com).</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
+        <xs:attribute name="pickupDirectoryLocation" type="SimpleLayoutAttribute">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Folder where applications save mail messages to be processed by the local SMTP server.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="timeout" type="xs:integer">
@@ -1799,19 +2691,19 @@
             <xs:documentation>Indicates the SMTP client timeout.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="smtpServer" type="SimpleLayoutAttribute">
+        <xs:attribute name="skipCertificateValidation" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>SMTP Server to be used for sending.</xs:documentation>
+            <xs:documentation>Indicates whether SmtpClient should ignore invalid certificate.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="smtpAuthentication" type="NLog.Targets.SmtpAuthenticationMode">
+        <xs:attribute name="smtpPort" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>SMTP Authentication mode.</xs:documentation>
+            <xs:documentation>Port number that SMTP Server is listening on.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="smtpUserName" type="SimpleLayoutAttribute">
+        <xs:attribute name="secureSocketOption" type="MailKit.Security.SecureSocketOptions">
           <xs:annotation>
-            <xs:documentation>Username used to connect to SMTP server (used when SmtpAuthentication is set to "basic").</xs:documentation>
+            <xs:documentation>Provides a way of specifying the SSL and/or TLS encryption If P:NLog.MailKit.MailTarget.EnableSsl is true, then F:MailKit.Security.SecureSocketOptions.SslOnConnect will be used.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="smtpPassword" type="SimpleLayoutAttribute">
@@ -1824,9 +2716,19 @@
             <xs:documentation>Indicates whether SSL (secure sockets layer) should be used when communicating with SMTP server.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="smtpPort" type="xs:integer">
+        <xs:attribute name="smtpUserName" type="SimpleLayoutAttribute">
           <xs:annotation>
-            <xs:documentation>Port number that SMTP Server is listening on.</xs:documentation>
+            <xs:documentation>Username used to connect to SMTP server (used when SmtpAuthentication is set to "basic").</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="smtpAuthentication" type="NLog.Targets.SmtpAuthenticationMode">
+          <xs:annotation>
+            <xs:documentation>SMTP Authentication mode.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="smtpServer" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>SMTP Server to be used for sending.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="useSystemNetMailSettings" type="xs:boolean">
@@ -1834,9 +2736,9 @@
             <xs:documentation>Indicates whether the default Settings from System.Net.MailSettings should be used.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="pickupDirectoryLocation" type="xs:string">
+        <xs:attribute name="requireTLS" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Folder where applications save mail messages to be processed by the local SMTP server.</xs:documentation>
+            <xs:documentation>Get or set whether the client should use the REQUIRETLS extension if it is available.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="deliveryMethod" type="System.Net.Mail.SmtpDeliveryMethod">
@@ -1847,11 +2749,28 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:simpleType name="System.Net.Mail.MailPriority">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Normal" />
+      <xs:enumeration value="Low" />
+      <xs:enumeration value="High" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MailKit.Security.SecureSocketOptions">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None" />
+      <xs:enumeration value="Auto" />
+      <xs:enumeration value="SslOnConnect" />
+      <xs:enumeration value="StartTls" />
+      <xs:enumeration value="StartTlsWhenAvailable" />
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="NLog.Targets.SmtpAuthenticationMode">
     <xs:restriction base="xs:string">
       <xs:enumeration value="None" />
       <xs:enumeration value="Basic" />
       <xs:enumeration value="Ntlm" />
+      <xs:enumeration value="OAuth2" />
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="System.Net.Mail.SmtpDeliveryMethod">
@@ -1865,9 +2784,43 @@
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="maxLogsCount" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="header" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Header.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="footer" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Footer.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxLogsCount" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Max number of items to have in memory. Zero or Negative means no limit.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="MessageBox">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="caption" type="Layout" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
@@ -1879,9 +2832,77 @@
             <xs:documentation>Layout used to format log messages.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+        <xs:attribute name="caption" type="SimpleLayoutAttribute">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Message box title.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="MSMQ">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="encoding" type="xs:string" minOccurs="0" maxOccurs="1" default="utf-8" />
+          <xs:element name="useXmlEncoding" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="checkIfQueueExists" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="createQueueIfNotExists" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="label" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="queue" type="Layout" minOccurs="1" maxOccurs="1" />
+          <xs:element name="recoverable" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="singleTransaction" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Layout used to format log messages.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="encoding" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Encoding to be used when writing text to the queue.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="useXmlEncoding" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to use the XML format when serializing message.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="checkIfQueueExists" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to check if a queue exists before writing to it.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="createQueueIfNotExists" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to create the queue if it doesn't exists.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="label" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Label to associate with each message.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="queue" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Name of the queue to write to.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="recoverable" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to use recoverable messages (with guaranteed delivery).</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="singleTransaction" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether sending to a transactional queue using single-transaction-style.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -1891,11 +2912,10 @@
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="className" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="methodName" minOccurs="0" maxOccurs="1" type="xs:string" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
           <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.MethodCallParameter" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="className" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="methodName" type="xs:string" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
@@ -1909,12 +2929,84 @@
         </xs:attribute>
         <xs:attribute name="methodName" type="xs:string">
           <xs:annotation>
-            <xs:documentation>Method name. The method must be public and static. Use the AssemblyQualifiedName , https://msdn.microsoft.com/en-us/library/system.type.assemblyqualifiedname(v=vs.110).aspx e.g.</xs:documentation>
+            <xs:documentation>Method name. The method must be public and static. Use the AssemblyQualifiedName - https://learn.microsoft.com/dotnet/api/system.type.assemblyqualifiedname</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="MicrosoftILogger">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="contextproperty" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.TargetPropertyWithContext" />
+          <xs:element name="includeCallSite" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeCallSiteStackTrace" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeGdc" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeScopeNested" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeScopeProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="excludeProperties" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="eventId" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="eventName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="loggerName" type="Layout" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
+        <xs:attribute name="includeCallSite" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to include call site (class and method name) in the T:NLog.LogEventInfo</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeCallSiteStackTrace" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to include source info (file name and line number) in the T:NLog.LogEventInfo</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeEventProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the P:NLog.LogEventInfo.Properties dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeGdc" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to include contents of the T:NLog.GlobalDiagnosticsContext dictionary</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopeNested" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.ScopeContext nested-state-stack.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopeProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.ScopeContext properties-dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="excludeProperties" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>List of property names to exclude when P:NLog.Targets.TargetWithContext.IncludeEventProperties is true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="eventId" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>EventId forwarded to ILogger</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="eventName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>EventId-Name forwarded to ILogger</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="loggerName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Override name of ILogger, when target has been initialized with T:Microsoft.Extensions.Logging.ILoggerFactory</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -1924,20 +3016,28 @@
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="encoding" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="lineEnding" minOccurs="0" maxOccurs="1" type="LineEndingMode" />
-          <xs:element name="maxMessageSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="newLine" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="address" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="connectionCacheSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="keepConnection" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="maxConnections" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="maxQueueSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="onConnectionOverflow" minOccurs="0" maxOccurs="1" type="NLog.Targets.NetworkTargetConnectionsOverflowAction" />
-          <xs:element name="onOverflow" minOccurs="0" maxOccurs="1" type="NLog.Targets.NetworkTargetOverflowAction" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslCertificatePassword" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslCertificateFile" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslProtocols" type="System.Security.Authentication.SslProtocols" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="sendTimeoutSeconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="100" />
+          <xs:element name="onOverflow" type="NLog.Targets.NetworkTargetOverflowAction" minOccurs="0" maxOccurs="1" default="Split" />
+          <xs:element name="onConnectionOverflow" type="NLog.Targets.NetworkTargetConnectionsOverflowAction" minOccurs="0" maxOccurs="1" default="Discard" />
+          <xs:element name="onQueueOverflow" type="NLog.Targets.NetworkTargetQueueOverflowAction" minOccurs="0" maxOccurs="1" default="Discard" />
+          <xs:element name="maxConnections" type="xs:integer" minOccurs="0" maxOccurs="1" default="100" />
+          <xs:element name="keepConnection" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="keepAliveTimeSeconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="connectionCacheSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="5" />
+          <xs:element name="address" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="maxQueueSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="10000" />
+          <xs:element name="compress" type="NLog.Targets.NetworkTargetCompressionType" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="compressMinBytes" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="noDelay" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="maxMessageSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="65000" />
+          <xs:element name="encoding" type="xs:string" minOccurs="0" maxOccurs="1" default="utf-8" />
+          <xs:element name="lineEnding" type="LineEndingMode" minOccurs="0" maxOccurs="1" />
+          <xs:element name="newLine" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
@@ -1949,34 +3049,44 @@
             <xs:documentation>Layout used to format log messages.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="encoding" type="xs:string">
+        <xs:attribute name="sslCertificatePassword" type="SimpleLayoutAttribute">
           <xs:annotation>
-            <xs:documentation>Encoding to be used.</xs:documentation>
+            <xs:documentation>Password for the custom SSL certificate specified by P:NLog.Targets.NetworkTarget.SslCertificateFile</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="lineEnding" type="LineEndingMode">
+        <xs:attribute name="sslCertificateFile" type="SimpleLayoutAttribute">
           <xs:annotation>
-            <xs:documentation>End of line value if a newline is appended at the end of log message .</xs:documentation>
+            <xs:documentation>File path to custom SSL certificate for TCP Socket SSL connections</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="maxMessageSize" type="xs:integer">
+        <xs:attribute name="sslProtocols" type="System.Security.Authentication.SslProtocols">
           <xs:annotation>
-            <xs:documentation>Maximum message size in bytes.</xs:documentation>
+            <xs:documentation>SSL/TLS protocols. Default no SSL/TLS is used. Currently only implemented for TCP.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="newLine" type="xs:boolean">
+        <xs:attribute name="sendTimeoutSeconds" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>Indicates whether to append newline at the end of log message.</xs:documentation>
+            <xs:documentation>The number of seconds a TCP socket send-operation will block before timeout error. Default = 100 secs (0 = wait forever when network cable unplugged and tcp-buffer becomes full).</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="address" type="SimpleLayoutAttribute">
+        <xs:attribute name="onOverflow" type="NLog.Targets.NetworkTargetOverflowAction">
           <xs:annotation>
-            <xs:documentation>Network address.</xs:documentation>
+            <xs:documentation>Action that should be taken if the message is larger than P:NLog.Targets.NetworkTarget.MaxMessageSize</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="connectionCacheSize" type="xs:integer">
+        <xs:attribute name="onConnectionOverflow" type="NLog.Targets.NetworkTargetConnectionsOverflowAction">
           <xs:annotation>
-            <xs:documentation>Size of the connection cache (number of connections which are kept alive).</xs:documentation>
+            <xs:documentation>Action that should be taken, when more connections than P:NLog.Targets.NetworkTarget.MaxConnections.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onQueueOverflow" type="NLog.Targets.NetworkTargetQueueOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken, when more pending messages than P:NLog.Targets.NetworkTarget.MaxQueueSize.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxConnections" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum simultaneous connections. Requires P:NLog.Targets.NetworkTarget.KeepConnection = false</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="keepConnection" type="xs:boolean">
@@ -1984,69 +3094,44 @@
             <xs:documentation>Indicates whether to keep connection open whenever possible.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="maxConnections" type="xs:integer">
+        <xs:attribute name="keepAliveTimeSeconds" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>Maximum current connections. 0 = no maximum.</xs:documentation>
+            <xs:documentation>The number of seconds a connection will remain idle before the first keep-alive probe is sent</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="connectionCacheSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Size of the connection cache (number of connections which are kept alive). Requires P:NLog.Targets.NetworkTarget.KeepConnection = true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="address" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Network destination address.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="maxQueueSize" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>Maximum queue size.</xs:documentation>
+            <xs:documentation>Maximum queue size for a single connection. Requires P:NLog.Targets.NetworkTarget.KeepConnection = true</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="onConnectionOverflow" type="NLog.Targets.NetworkTargetConnectionsOverflowAction">
+        <xs:attribute name="compress" type="NLog.Targets.NetworkTargetCompressionType">
           <xs:annotation>
-            <xs:documentation>Action that should be taken if the will be more connections than .</xs:documentation>
+            <xs:documentation>Type of compression for protocol payload. Useful for UDP where datagram max-size is 8192 bytes.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="onOverflow" type="NLog.Targets.NetworkTargetOverflowAction">
+        <xs:attribute name="compressMinBytes" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>Action that should be taken if the message is larger than maxMessageSize.</xs:documentation>
+            <xs:documentation>Skip compression when protocol payload is below limit to reduce overhead in cpu-usage and additional headers</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+        <xs:attribute name="noDelay" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Whether to disable the delayed ACK timer, and avoid delay of 200 ms.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="NLogViewer">
-    <xs:complexContent>
-      <xs:extension base="Target">
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="encoding" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="lineEnding" minOccurs="0" maxOccurs="1" type="LineEndingMode" />
-          <xs:element name="maxMessageSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="newLine" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="onConnectionOverflow" minOccurs="0" maxOccurs="1" type="NLog.Targets.NetworkTargetConnectionsOverflowAction" />
-          <xs:element name="maxQueueSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="maxConnections" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="keepConnection" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="connectionCacheSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="address" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="onOverflow" minOccurs="0" maxOccurs="1" type="NLog.Targets.NetworkTargetOverflowAction" />
-          <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.NLogViewerParameterInfo" />
-          <xs:element name="ndlcItemSeparator" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="ndcItemSeparator" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="includeNLogData" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeSourceInfo" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeNdlc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeNdc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeMdlc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeMdc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeCallSite" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeAllProperties" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="appInfo" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="loggerName" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-        </xs:choice>
-        <xs:attribute name="name" type="xs:string">
+        <xs:attribute name="maxMessageSize" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>Name of the target.</xs:documentation>
+            <xs:documentation>Maximum message size in bytes. On limit breach then P:NLog.Targets.NetworkTarget.OnOverflow action is activated.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="encoding" type="xs:string">
@@ -2054,124 +3139,14 @@
             <xs:documentation>Encoding to be used.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="layout" type="SimpleLayoutAttribute">
-          <xs:annotation>
-            <xs:documentation>Instance of  that is used to format log messages.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="lineEnding" type="LineEndingMode">
           <xs:annotation>
-            <xs:documentation>End of line value if a newline is appended at the end of log message .</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="maxMessageSize" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Maximum message size in bytes.</xs:documentation>
+            <xs:documentation>End of line value if a newline is appended at the end of log message P:NLog.Targets.NetworkTarget.NewLine.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="newLine" type="xs:boolean">
           <xs:annotation>
             <xs:documentation>Indicates whether to append newline at the end of log message.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="onConnectionOverflow" type="NLog.Targets.NetworkTargetConnectionsOverflowAction">
-          <xs:annotation>
-            <xs:documentation>Action that should be taken if the will be more connections than .</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="maxQueueSize" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Maximum queue size.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="maxConnections" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Maximum current connections. 0 = no maximum.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="keepConnection" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to keep connection open whenever possible.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="connectionCacheSize" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Size of the connection cache (number of connections which are kept alive).</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="address" type="SimpleLayoutAttribute">
-          <xs:annotation>
-            <xs:documentation>Network address.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="onOverflow" type="NLog.Targets.NetworkTargetOverflowAction">
-          <xs:annotation>
-            <xs:documentation>Action that should be taken if the message is larger than maxMessageSize.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="ndlcItemSeparator" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>NDLC item separator.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="ndcItemSeparator" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>NDC item separator.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeNLogData" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include NLog-specific extensions to log4j schema.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeSourceInfo" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include source info (file name and line number) in the information sent over the network.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeNdlc" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include contents of the  stack.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeNdc" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include  stack contents.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeMdlc" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include  dictionary contents.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeMdc" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include  dictionary contents.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeCallSite" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include call site (class and method name) in the information sent over the network.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeAllProperties" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Option to include all properties from the log events</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="appInfo" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>AppInfo field. By default it's the friendly name of the current AppDomain.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="loggerName" type="SimpleLayoutAttribute">
-          <xs:annotation>
-            <xs:documentation>Renderer for log4j:event logger-xml-attribute (Default ${logger})</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -2181,10 +3156,9 @@
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="formatMessage" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="formatMessage" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
@@ -2198,12 +3172,7 @@
         </xs:attribute>
         <xs:attribute name="formatMessage" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Indicates whether to perform layout calculation.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Indicates whether to render P:NLog.Targets.TargetWithLayout.Layout for LogEvent</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -2213,25 +3182,27 @@
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="layout" type="SimpleLayoutAttribute">
+        <xs:attribute name="header" type="SimpleLayoutAttribute">
           <xs:annotation>
-            <xs:documentation>Layout used to format log messages.</xs:documentation>
+            <xs:documentation>Header.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+        <xs:attribute name="footer" type="SimpleLayoutAttribute">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Footer.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -2239,15 +3210,14 @@
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="autoCreate" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="categoryName" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="counterHelp" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="counterName" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="counterType" minOccurs="0" maxOccurs="1" type="System.Diagnostics.PerformanceCounterType" />
-          <xs:element name="incrementValue" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="instanceName" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="autoCreate" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="categoryName" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="counterHelp" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="counterName" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="counterType" type="System.Diagnostics.PerformanceCounterType" minOccurs="0" maxOccurs="1" default="NumberOfItems32" />
+          <xs:element name="incrementValue" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="instanceName" type="xs:string" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
@@ -2289,11 +3259,6 @@
             <xs:documentation>Performance counter instance name.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -2333,10 +3298,9 @@
     <xs:complexContent>
       <xs:extension base="WrapperTargetBase">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="defaultFilter" minOccurs="0" maxOccurs="1" type="Condition" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="defaultFilter" type="Condition" minOccurs="0" maxOccurs="1" />
           <xs:element name="when" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.Wrappers.FilteringRule" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
@@ -2348,18 +3312,13 @@
             <xs:documentation>Default filter to be applied when no specific rule matches.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
   <xs:complexType name="NLog.Targets.Wrappers.FilteringRule">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="exists" minOccurs="0" maxOccurs="1" type="Condition" />
-      <xs:element name="filter" minOccurs="0" maxOccurs="1" type="Condition" />
+      <xs:element name="exists" type="Condition" minOccurs="0" maxOccurs="1" />
+      <xs:element name="filter" type="Condition" minOccurs="0" maxOccurs="1" />
     </xs:choice>
     <xs:attribute name="exists" type="Condition">
       <xs:annotation>
@@ -2376,17 +3335,11 @@
     <xs:complexContent>
       <xs:extension base="CompoundTargetBase">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -2396,18 +3349,12 @@
     <xs:complexContent>
       <xs:extension base="WrapperTargetBase">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="repeatCount" minOccurs="0" maxOccurs="1" type="xs:integer" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="repeatCount" type="xs:integer" minOccurs="0" maxOccurs="1" default="3" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="repeatCount" type="xs:integer">
@@ -2422,19 +3369,19 @@
     <xs:complexContent>
       <xs:extension base="WrapperTargetBase">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="retryCount" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="retryDelayMilliseconds" minOccurs="0" maxOccurs="1" type="xs:integer" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="enableBatchWrite" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="retryCount" type="xs:integer" minOccurs="0" maxOccurs="1" default="3" />
+          <xs:element name="retryDelayMilliseconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="100" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+        <xs:attribute name="enableBatchWrite" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Whether to enable batching, and only apply single delay when a whole batch fails</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="retryCount" type="xs:integer">
@@ -2450,54 +3397,27 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="RoundRobinGroup">
-    <xs:complexContent>
-      <xs:extension base="CompoundTargetBase">
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-        </xs:choice>
-        <xs:attribute name="name" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>Name of the target.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="SplitGroup">
-    <xs:complexContent>
-      <xs:extension base="CompoundTargetBase">
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-        </xs:choice>
-        <xs:attribute name="name" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>Name of the target.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="Trace">
+  <xs:complexType name="RichTextBox">
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="rawWrite" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="width" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="toolWindow" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="showMinimized" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="maxLines" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="messageRetention" type="NLog.Windows.Forms.RichTextBoxTargetMessageRetentionStrategy" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="formName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="controlName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="autoScroll" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="allowAccessoryFormCreation" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="height" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="useDefaultRowColoringRules" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="row-coloring" minOccurs="0" maxOccurs="unbounded" type="NLog.Windows.Forms.RichTextBoxRowColoringRule" />
+          <xs:element name="word-coloring" minOccurs="0" maxOccurs="unbounded" type="NLog.Windows.Forms.RichTextBoxWordColoringRule" />
+          <xs:element name="createdForm" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="supportLinks" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
@@ -2509,14 +3429,665 @@
             <xs:documentation>Layout used to format log messages.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="rawWrite" type="xs:boolean">
+        <xs:attribute name="width" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>Always use  independent of </xs:documentation>
+            <xs:documentation>Initial width of the form with rich text box.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+        <xs:attribute name="toolWindow" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Indicates whether the created window will be a tool window.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="showMinimized" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether the created form will be initially minimized.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxLines" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum number of lines the rich text box will store (or 0 to disable this feature).</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="messageRetention" type="NLog.Windows.Forms.RichTextBoxTargetMessageRetentionStrategy">
+          <xs:annotation>
+            <xs:documentation>gets or sets the message retention strategy which determines how the target handles messages when there's no control attached, or when switching between controls</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="formName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Name of the Form on which the control is located. If there is no open form of a specified name than NLog will create a new one.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="controlName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Name of RichTextBox to which Nlog will write.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="autoScroll" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether scroll bar will be moved automatically to show most recent log entries.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="allowAccessoryFormCreation" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to create accessory form if the specified form/control combination was not found during target initialization.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="height" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Initial height of the form with rich text box.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="useDefaultRowColoringRules" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to use default coloring rules.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="createdForm" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Form created (true) or used an existing (false). Set after M:NLog.Windows.Forms.RichTextBoxTarget.InitializeTarget. Can be true only if P:NLog.Windows.Forms.RichTextBoxTarget.AllowAccessoryFormCreation is set to true (default).</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="supportLinks" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>If set to true, using "rtb-link" renderer (T:NLog.Windows.Forms.RichTextBoxLinkLayoutRenderer) would create clickable links in the control. E:NLog.Windows.Forms.RichTextBoxTarget.LinkClicked</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="NLog.Windows.Forms.RichTextBoxTargetMessageRetentionStrategy">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None" />
+      <xs:enumeration value="OnlyMissed" />
+      <xs:enumeration value="All" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="System.Drawing.FontStyle">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Regular" />
+      <xs:enumeration value="Bold" />
+      <xs:enumeration value="Italic" />
+      <xs:enumeration value="Underline" />
+      <xs:enumeration value="Strikeout" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="NLog.Windows.Forms.RichTextBoxRowColoringRule">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="backgroundColor" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="fontColor" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="style" type="System.Drawing.FontStyle" minOccurs="0" maxOccurs="1" default="Regular" />
+      <xs:element name="condition" type="Condition" minOccurs="0" maxOccurs="1" />
+    </xs:choice>
+    <xs:attribute name="backgroundColor" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Background color.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="fontColor" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Font color.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="style" type="System.Drawing.FontStyle">
+      <xs:annotation>
+        <xs:documentation>Font style of matched text.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="condition" type="Condition">
+      <xs:annotation>
+        <xs:documentation>Condition that must be met in order to set the specified font color.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="NLog.Windows.Forms.RichTextBoxWordColoringRule">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="backgroundColor" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="fontColor" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="style" type="System.Drawing.FontStyle" minOccurs="0" maxOccurs="1" default="Regular" />
+      <xs:element name="ignoreCase" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+      <xs:element name="regex" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="text" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="wholeWords" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+    </xs:choice>
+    <xs:attribute name="backgroundColor" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Background color. Names are identical with KnownColor enum extended with Empty value which means that background color won't be changed.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="fontColor" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Font color. Names are identical with KnownColor enum extended with Empty value which means that font color won't be changed.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="style" type="System.Drawing.FontStyle">
+      <xs:annotation>
+        <xs:documentation>Font style of matched text. Possible values are the same as in FontStyle enum in System.Drawing.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="ignoreCase" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Indicates whether to ignore case when comparing texts.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="regex" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Regular expression to be matched. You must specify either text or regex.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="text" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Text to be matched. You must specify either text or regex.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="wholeWords" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Indicates whether to match whole words only.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="RoundRobinGroup">
+    <xs:complexContent>
+      <xs:extension base="CompoundTargetBase">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="SplitGroup">
+    <xs:complexContent>
+      <xs:extension base="CompoundTargetBase">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="Splunk">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslCertificatePassword" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslCertificateFile" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslProtocols" type="System.Security.Authentication.SslProtocols" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="sendTimeoutSeconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="100" />
+          <xs:element name="onOverflow" type="NLog.Targets.NetworkTargetOverflowAction" minOccurs="0" maxOccurs="1" default="Split" />
+          <xs:element name="onConnectionOverflow" type="NLog.Targets.NetworkTargetConnectionsOverflowAction" minOccurs="0" maxOccurs="1" default="Discard" />
+          <xs:element name="onQueueOverflow" type="NLog.Targets.NetworkTargetQueueOverflowAction" minOccurs="0" maxOccurs="1" default="Discard" />
+          <xs:element name="maxConnections" type="xs:integer" minOccurs="0" maxOccurs="1" default="100" />
+          <xs:element name="keepConnection" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="keepAliveTimeSeconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="connectionCacheSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="5" />
+          <xs:element name="address" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="maxQueueSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="10000" />
+          <xs:element name="SplunkField" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.JsonAttribute" />
+          <xs:element name="splunkSourceType" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="splunkSourceName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="splunkIndex" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="splunkHostName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="noDelay" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="compressMinBytes" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="includeScopeProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="excludeProperties" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="excludeEmptyProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="compress" type="NLog.Targets.NetworkTargetCompressionType" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="maxMessageSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="65000" />
+          <xs:element name="encoding" type="xs:string" minOccurs="0" maxOccurs="1" default="utf-8" />
+          <xs:element name="lineEnding" type="LineEndingMode" minOccurs="0" maxOccurs="1" />
+          <xs:element name="newLine" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sslCertificatePassword" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Password for the custom SSL certificate specified by P:NLog.Targets.NetworkTarget.SslCertificateFile</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sslCertificateFile" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>File path to custom SSL certificate for TCP Socket SSL connections</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sslProtocols" type="System.Security.Authentication.SslProtocols">
+          <xs:annotation>
+            <xs:documentation>SSL/TLS protocols. Default no SSL/TLS is used. Currently only implemented for TCP.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sendTimeoutSeconds" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>The number of seconds a TCP socket send-operation will block before timeout error. Default = 100 secs (0 = wait forever when network cable unplugged and tcp-buffer becomes full).</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onOverflow" type="NLog.Targets.NetworkTargetOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken if the message is larger than P:NLog.Targets.NetworkTarget.MaxMessageSize</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onConnectionOverflow" type="NLog.Targets.NetworkTargetConnectionsOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken, when more connections than P:NLog.Targets.NetworkTarget.MaxConnections.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onQueueOverflow" type="NLog.Targets.NetworkTargetQueueOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken, when more pending messages than P:NLog.Targets.NetworkTarget.MaxQueueSize.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxConnections" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum simultaneous connections. Requires P:NLog.Targets.NetworkTarget.KeepConnection = false</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepConnection" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to keep connection open whenever possible.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepAliveTimeSeconds" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>The number of seconds a connection will remain idle before the first keep-alive probe is sent</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="connectionCacheSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Size of the connection cache (number of connections which are kept alive). Requires P:NLog.Targets.NetworkTarget.KeepConnection = true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="address" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Network destination address.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxQueueSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum queue size for a single connection. Requires P:NLog.Targets.NetworkTarget.KeepConnection = true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="splunkSourceType" type="SimpleLayoutAttribute" />
+        <xs:attribute name="splunkSourceName" type="SimpleLayoutAttribute" />
+        <xs:attribute name="splunkIndex" type="SimpleLayoutAttribute" />
+        <xs:attribute name="splunkHostName" type="SimpleLayoutAttribute" />
+        <xs:attribute name="noDelay" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to disable the delayed ACK timer, and avoid delay of 200 ms.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="compressMinBytes" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Skip compression when protocol payload is below limit to reduce overhead in cpu-usage and additional headers</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopeProperties" type="xs:boolean" />
+        <xs:attribute name="includeEventProperties" type="xs:boolean" />
+        <xs:attribute name="excludeProperties" type="xs:string" />
+        <xs:attribute name="excludeEmptyProperties" type="xs:boolean" />
+        <xs:attribute name="compress" type="NLog.Targets.NetworkTargetCompressionType">
+          <xs:annotation>
+            <xs:documentation>Type of compression for protocol payload. Useful for UDP where datagram max-size is 8192 bytes.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
+        <xs:attribute name="maxMessageSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum message size in bytes. On limit breach then P:NLog.Targets.NetworkTarget.OnOverflow action is activated.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="encoding" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Encoding to be used.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="lineEnding" type="LineEndingMode">
+          <xs:annotation>
+            <xs:documentation>End of line value if a newline is appended at the end of log message P:NLog.Targets.NetworkTarget.NewLine.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="newLine" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to append newline at the end of log message.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="NLog.Layouts.JsonAttribute">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="defaultValue" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="encode" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+      <xs:element name="escapeUnicode" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+      <xs:element name="includeEmptyValue" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+      <xs:element name="valueType" type="xs:string" minOccurs="0" maxOccurs="1" />
+    </xs:choice>
+    <xs:attribute name="name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Name of the attribute.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="layout" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Layout used for rendering the attribute value.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="defaultValue" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Fallback value when result value is not available</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="encode" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Whether output should be encoded as Json-String-Property, or be treated as valid json.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="escapeUnicode" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Indicates whether to escape non-ascii characters</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="includeEmptyValue" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Whether empty attribute value should be included in the output.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="valueType" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Result value type, for conversion of layout rendering output</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="Syslog">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslCertificatePassword" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslCertificateFile" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="sslProtocols" type="System.Security.Authentication.SslProtocols" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="onQueueOverflow" type="NLog.Targets.NetworkTargetQueueOverflowAction" minOccurs="0" maxOccurs="1" default="Discard" />
+          <xs:element name="onOverflow" type="NLog.Targets.NetworkTargetOverflowAction" minOccurs="0" maxOccurs="1" default="Split" />
+          <xs:element name="onConnectionOverflow" type="NLog.Targets.NetworkTargetConnectionsOverflowAction" minOccurs="0" maxOccurs="1" default="Discard" />
+          <xs:element name="sendTimeoutSeconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="100" />
+          <xs:element name="maxConnections" type="xs:integer" minOccurs="0" maxOccurs="1" default="100" />
+          <xs:element name="keepConnection" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="keepAliveTimeSeconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="connectionCacheSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="5" />
+          <xs:element name="address" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="maxQueueSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="10000" />
+          <xs:element name="syslogFacility" type="NLog.Layouts.SyslogFacility" minOccurs="0" maxOccurs="1" default="User" />
+          <xs:element name="syslogTimestamp" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="syslogProcessId" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="syslogMessageId" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="syslogMessage" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="syslogLevel" type="NLog.Layouts.SyslogLevel" minOccurs="0" maxOccurs="1" />
+          <xs:element name="syslogHostName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="syslogAppName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="structuredDataId" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="rfc5424" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="rfc3164" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="noDelay" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="compressMinBytes" type="xs:integer" minOccurs="0" maxOccurs="1" default="0" />
+          <xs:element name="compress" type="NLog.Targets.NetworkTargetCompressionType" minOccurs="0" maxOccurs="1" default="None" />
+          <xs:element name="StructuredDataParam" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.TargetPropertyWithContext" />
+          <xs:element name="maxMessageSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="65000" />
+          <xs:element name="encoding" type="xs:string" minOccurs="0" maxOccurs="1" default="utf-8" />
+          <xs:element name="lineEnding" type="LineEndingMode" minOccurs="0" maxOccurs="1" />
+          <xs:element name="newLine" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sslCertificatePassword" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Password for the custom SSL certificate specified by P:NLog.Targets.NetworkTarget.SslCertificateFile</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sslCertificateFile" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>File path to custom SSL certificate for TCP Socket SSL connections</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sslProtocols" type="System.Security.Authentication.SslProtocols">
+          <xs:annotation>
+            <xs:documentation>SSL/TLS protocols. Default no SSL/TLS is used. Currently only implemented for TCP.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onQueueOverflow" type="NLog.Targets.NetworkTargetQueueOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken, when more pending messages than P:NLog.Targets.NetworkTarget.MaxQueueSize.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onOverflow" type="NLog.Targets.NetworkTargetOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken if the message is larger than P:NLog.Targets.NetworkTarget.MaxMessageSize</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="onConnectionOverflow" type="NLog.Targets.NetworkTargetConnectionsOverflowAction">
+          <xs:annotation>
+            <xs:documentation>Action that should be taken, when more connections than P:NLog.Targets.NetworkTarget.MaxConnections.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sendTimeoutSeconds" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>The number of seconds a TCP socket send-operation will block before timeout error. Default = 100 secs (0 = wait forever when network cable unplugged and tcp-buffer becomes full).</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxConnections" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum simultaneous connections. Requires P:NLog.Targets.NetworkTarget.KeepConnection = false</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepConnection" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to keep connection open whenever possible.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepAliveTimeSeconds" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>The number of seconds a connection will remain idle before the first keep-alive probe is sent</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="connectionCacheSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Size of the connection cache (number of connections which are kept alive). Requires P:NLog.Targets.NetworkTarget.KeepConnection = true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="address" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Network destination address.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxQueueSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum queue size for a single connection. Requires P:NLog.Targets.NetworkTarget.KeepConnection = true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="syslogFacility" type="NLog.Layouts.SyslogFacility" />
+        <xs:attribute name="syslogTimestamp" type="SimpleLayoutAttribute" />
+        <xs:attribute name="syslogProcessId" type="SimpleLayoutAttribute" />
+        <xs:attribute name="syslogMessageId" type="SimpleLayoutAttribute" />
+        <xs:attribute name="syslogMessage" type="SimpleLayoutAttribute" />
+        <xs:attribute name="syslogLevel" type="NLog.Layouts.SyslogLevel" />
+        <xs:attribute name="syslogHostName" type="SimpleLayoutAttribute" />
+        <xs:attribute name="syslogAppName" type="SimpleLayoutAttribute" />
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
+        <xs:attribute name="structuredDataId" type="SimpleLayoutAttribute" />
+        <xs:attribute name="rfc5424" type="xs:boolean" />
+        <xs:attribute name="rfc3164" type="xs:boolean" />
+        <xs:attribute name="noDelay" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to disable the delayed ACK timer, and avoid delay of 200 ms.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeEventProperties" type="xs:boolean" />
+        <xs:attribute name="compressMinBytes" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Skip compression when protocol payload is below limit to reduce overhead in cpu-usage and additional headers</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="compress" type="NLog.Targets.NetworkTargetCompressionType">
+          <xs:annotation>
+            <xs:documentation>Type of compression for protocol payload. Useful for UDP where datagram max-size is 8192 bytes.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxMessageSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Maximum message size in bytes. On limit breach then P:NLog.Targets.NetworkTarget.OnOverflow action is activated.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="encoding" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Encoding to be used.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="lineEnding" type="LineEndingMode">
+          <xs:annotation>
+            <xs:documentation>End of line value if a newline is appended at the end of log message P:NLog.Targets.NetworkTarget.NewLine.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="newLine" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to append newline at the end of log message.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="NLog.Layouts.SyslogFacility">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Kernel" />
+      <xs:enumeration value="User" />
+      <xs:enumeration value="Mail" />
+      <xs:enumeration value="Daemons" />
+      <xs:enumeration value="Authorization" />
+      <xs:enumeration value="Syslog" />
+      <xs:enumeration value="Printer" />
+      <xs:enumeration value="News" />
+      <xs:enumeration value="Uucp" />
+      <xs:enumeration value="Clock" />
+      <xs:enumeration value="Authorization2" />
+      <xs:enumeration value="Ftp" />
+      <xs:enumeration value="Ntp" />
+      <xs:enumeration value="Audit" />
+      <xs:enumeration value="Alert" />
+      <xs:enumeration value="Clock2" />
+      <xs:enumeration value="Local0" />
+      <xs:enumeration value="Local1" />
+      <xs:enumeration value="Local2" />
+      <xs:enumeration value="Local3" />
+      <xs:enumeration value="Local4" />
+      <xs:enumeration value="Local5" />
+      <xs:enumeration value="Local6" />
+      <xs:enumeration value="Local7" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="NLog.Layouts.SyslogLevel">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Emergency" />
+      <xs:enumeration value="Alert" />
+      <xs:enumeration value="Critical" />
+      <xs:enumeration value="Error" />
+      <xs:enumeration value="Warning" />
+      <xs:enumeration value="Notice" />
+      <xs:enumeration value="Informational" />
+      <xs:enumeration value="Debug" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="ToolStripItem">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="formName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="itemName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="toolStripName" type="Layout" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Layout used to format log messages.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="formName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Name of the Form on which the ToolStrip is located.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="itemName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Name of the ToolStripItem to which NLog will log write log text.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="toolStripName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Name of ToolStrip that contains the ToolStripItem to which NLog will log write log text.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="Trace">
+    <xs:complexContent>
+      <xs:extension base="Target">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="enableTraceFail" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="rawWrite" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="header" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Header.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="footer" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Footer.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute" />
+        <xs:attribute name="enableTraceFail" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Forward F:NLog.LogLevel.Fatal to M:System.Diagnostics.Trace.Fail(System.String) (Instead of M:System.Diagnostics.Trace.TraceError(System.String))</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="rawWrite" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Force use M:System.Diagnostics.Trace.WriteLine(System.String) independent of T:NLog.LogLevel</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -2526,37 +4097,41 @@
     <xs:complexContent>
       <xs:extension base="Target">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
+          <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
           <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.MethodCallParameter" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeBOM" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="methodName" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="namespace" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="protocol" minOccurs="0" maxOccurs="1" type="NLog.Targets.WebServiceProtocol" />
-          <xs:element name="proxyAddress" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="encoding" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="url" minOccurs="0" maxOccurs="1" type="xs:anyURI" />
-          <xs:element name="escapeDataNLogLegacy" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="escapeDataRfc3986" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="preAuthenticate" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="xmlRoot" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="xmlRootNamespace" minOccurs="0" maxOccurs="1" type="xs:string" />
+          <xs:element name="expect100Continue" type="xs:boolean" minOccurs="0" maxOccurs="1" />
+          <xs:element name="encoding" type="xs:string" minOccurs="0" maxOccurs="1" default="utf-8" />
           <xs:element name="header" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.MethodCallParameter" />
-          <xs:element name="proxyType" minOccurs="0" maxOccurs="1" type="NLog.Targets.WebServiceProxyType" />
+          <xs:element name="includeBOM" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="methodName" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="namespace" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="protocol" type="NLog.Targets.WebServiceProtocol" minOccurs="0" maxOccurs="1" default="Soap11" />
+          <xs:element name="proxyAddress" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="proxyType" type="NLog.Targets.WebServiceProxyType" minOccurs="0" maxOccurs="1" default="NoProxy" />
+          <xs:element name="url" type="xs:anyURI" minOccurs="0" maxOccurs="1" />
+          <xs:element name="userAgent" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="preAuthenticate" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="xmlRoot" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="xmlRootNamespace" type="xs:string" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="name" type="xs:string">
           <xs:annotation>
             <xs:documentation>Name of the target.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
+        <xs:attribute name="expect100Continue" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Target supports reuse of internal buffers, and doesn't have to constantly allocate new buffers Required for legacy NLog-targets, that expects buffers to remain stable after Write-method exit</xs:documentation>
+            <xs:documentation>Indicates whether to expect http 100-Continue behavior, where the client sends headers and expects a 100-Continue response from the server before sending the request body.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="encoding" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Encoding.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="includeBOM" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Should we include the BOM (Byte-order-mark) for UTF? Influences the  property. This will only work for UTF-8.</xs:documentation>
+            <xs:documentation>Should we include the BOM (Byte-order-mark) for UTF? Influences the P:NLog.Targets.WebServiceTarget.Encoding property. This will only work for UTF-8.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="methodName" type="xs:string">
@@ -2574,14 +4149,14 @@
             <xs:documentation>Protocol to be used when calling web service.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="proxyAddress" type="xs:string">
+        <xs:attribute name="proxyAddress" type="SimpleLayoutAttribute">
           <xs:annotation>
             <xs:documentation>Custom proxy address, include port separated by a colon</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="encoding" type="xs:string">
+        <xs:attribute name="proxyType" type="NLog.Targets.WebServiceProxyType">
           <xs:annotation>
-            <xs:documentation>Encoding.</xs:documentation>
+            <xs:documentation>Proxy configuration when calling web service</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="url" type="xs:anyURI">
@@ -2589,34 +4164,24 @@
             <xs:documentation>Web service URL.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="escapeDataNLogLegacy" type="xs:boolean">
+        <xs:attribute name="userAgent" type="SimpleLayoutAttribute">
           <xs:annotation>
-            <xs:documentation>Value whether escaping be done according to the old NLog style (Very non-standard)</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="escapeDataRfc3986" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Value whether escaping be done according to Rfc3986 (Supports Internationalized Resource Identifiers - IRIs)</xs:documentation>
+            <xs:documentation>Value of the User-agent HTTP header.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="preAuthenticate" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Indicates whether to pre-authenticate the HttpWebRequest (Requires 'Authorization' in  parameters)</xs:documentation>
+            <xs:documentation>Indicates whether to pre-authenticate the HttpWebRequest (Requires 'Authorization' in P:NLog.Targets.WebServiceTarget.Headers parameters)</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="xmlRoot" type="xs:string">
           <xs:annotation>
-            <xs:documentation>Name of the root XML element, if POST of XML document chosen. If so, this property must not be null. (see  and ).</xs:documentation>
+            <xs:documentation>Name of the root XML element, if POST of XML document chosen. If so, this property must not be null. (see P:NLog.Targets.WebServiceTarget.Protocol and F:NLog.Targets.WebServiceProtocol.XmlPost).</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="xmlRootNamespace" type="xs:string">
           <xs:annotation>
-            <xs:documentation>(optional) root namespace of the XML document, if POST of XML document chosen. (see  and ).</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="proxyType" type="NLog.Targets.WebServiceProxyType">
-          <xs:annotation>
-            <xs:documentation>Proxy configuration when calling web service</xs:documentation>
+            <xs:documentation>(optional) root namespace of the XML document, if POST of XML document chosen. (see P:NLog.Targets.WebServiceTarget.Protocol and F:NLog.Targets.WebServiceProtocol.XmlPost).</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -2656,16 +4221,26 @@
     <xs:complexContent>
       <xs:extension base="Layout">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="footer" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="header" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
           <xs:element name="column" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.CsvColumn" />
-          <xs:element name="customColumnDelimiter" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="delimiter" minOccurs="0" maxOccurs="1" type="NLog.Layouts.CsvColumnDelimiterMode" />
-          <xs:element name="quoteChar" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="quoting" minOccurs="0" maxOccurs="1" type="NLog.Layouts.CsvQuotingMode" />
-          <xs:element name="withHeader" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="customColumnDelimiter" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="delimiter" type="NLog.Layouts.CsvColumnDelimiterMode" minOccurs="0" maxOccurs="1" default="Auto" />
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="quoteChar" type="xs:string" minOccurs="0" maxOccurs="1" default="&quot;" />
+          <xs:element name="quoting" type="NLog.Layouts.CsvQuotingMode" minOccurs="0" maxOccurs="1" default="Auto" />
+          <xs:element name="withHeader" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
         </xs:choice>
+        <xs:attribute name="customColumnDelimiter" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Custom column delimiter value (valid when P:NLog.Layouts.CsvLayout.Delimiter is set to F:NLog.Layouts.CsvColumnDelimiterMode.Custom).</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="delimiter" type="NLog.Layouts.CsvColumnDelimiterMode">
+          <xs:annotation>
+            <xs:documentation>Column delimiter.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="footer" type="SimpleLayoutAttribute">
           <xs:annotation>
             <xs:documentation>Footer layout.</xs:documentation>
@@ -2681,16 +4256,6 @@
             <xs:documentation>Body layout (can be repeated multiple times).</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="customColumnDelimiter" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>Custom column delimiter value (valid when ColumnDelimiter is set to 'Custom').</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="delimiter" type="NLog.Layouts.CsvColumnDelimiterMode">
-          <xs:annotation>
-            <xs:documentation>Column delimiter.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="quoteChar" type="xs:string">
           <xs:annotation>
             <xs:documentation>Quote Character.</xs:documentation>
@@ -2703,12 +4268,19 @@
         </xs:attribute>
         <xs:attribute name="withHeader" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Indicates whether CVS should include header.</xs:documentation>
+            <xs:documentation>Indicates whether CSV should include header.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:simpleType name="NLog.Layouts.CsvQuotingMode">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="All" />
+      <xs:enumeration value="Nothing" />
+      <xs:enumeration value="Auto" />
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="NLog.Layouts.CsvColumnDelimiterMode">
     <xs:restriction base="xs:string">
       <xs:enumeration value="Auto" />
@@ -2720,60 +4292,167 @@
       <xs:enumeration value="Custom" />
     </xs:restriction>
   </xs:simpleType>
-  <xs:simpleType name="NLog.Layouts.CsvQuotingMode">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="All" />
-      <xs:enumeration value="Nothing" />
-      <xs:enumeration value="Auto" />
-    </xs:restriction>
-  </xs:simpleType>
   <xs:complexType name="NLog.Layouts.CsvColumn">
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-      <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="quoting" type="NLog.Layouts.CsvQuotingMode" minOccurs="0" maxOccurs="1" default="Auto" />
     </xs:choice>
-    <xs:attribute name="layout" type="SimpleLayoutAttribute">
-      <xs:annotation>
-        <xs:documentation>Layout of the column.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
     <xs:attribute name="name" type="xs:string">
       <xs:annotation>
         <xs:documentation>Name of the column.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="layout" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Layout used for rendering the column value.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="quoting" type="NLog.Layouts.CsvQuotingMode">
+      <xs:annotation>
+        <xs:documentation>Override of Quoting mode</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="GelfLayout">
+    <xs:complexContent>
+      <xs:extension base="Layout">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="layout" minOccurs="0" maxOccurs="unbounded" type="Layout" />
+          <xs:element name="excludeEmptyProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="excludeProperties" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="gelfFacility" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="GelfField" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.TargetPropertyWithContext" />
+          <xs:element name="gelfFullMessage" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="gelfHostName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="gelfShortMessage" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeProperties" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="includeScopeProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+        </xs:choice>
+        <xs:attribute name="excludeEmptyProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to exclude null/empty properties from the log event (as JSON)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="excludeProperties" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>List of property names to exclude when P:NLog.Layouts.GelfLayout.IncludeEventProperties is true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="gelfFacility" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Whether to activate the legacy Graylog Message Facility-field</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="gelfFullMessage" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Graylog Message Full-Message-field</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="gelfHostName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Graylog Message Host-field</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="gelfShortMessage" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Graylog Message Short-Message-field</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeEventProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to include all properties from the log events</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeProperties" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>List of property names to include when P:NLog.Layouts.GelfLayout.IncludeEventProperties is true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopeProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.ScopeContext properties-dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="JsonArrayLayout">
+    <xs:complexContent>
+      <xs:extension base="Layout">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="item" minOccurs="0" maxOccurs="unbounded" type="Layout" />
+          <xs:element name="renderEmptyObject" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="suppressSpaces" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+        </xs:choice>
+        <xs:attribute name="renderEmptyObject" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to render the empty object value {}</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="suppressSpaces" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to suppress the extra spaces in the output json.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
   <xs:complexType name="JsonLayout">
     <xs:complexContent>
       <xs:extension base="Layout">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
           <xs:element name="attribute" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.JsonAttribute" />
-          <xs:element name="excludeProperties" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="includeAllProperties" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeMdc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeMdlc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="renderEmptyObject" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="suppressSpaces" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="maxRecursionLimit" minOccurs="0" maxOccurs="1" type="xs:integer" />
+          <xs:element name="dottedRecursion" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeGdc" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeScopeProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="excludeEmptyProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="excludeProperties" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="indentJson" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="maxRecursionLimit" type="xs:integer" minOccurs="0" maxOccurs="1" default="1" />
+          <xs:element name="renderEmptyObject" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="suppressSpaces" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
         </xs:choice>
+        <xs:attribute name="dottedRecursion" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to flatten nested object properties using dotted notation (avoid nested JSON output)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeEventProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the P:NLog.LogEventInfo.Properties dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeGdc" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.GlobalDiagnosticsContext dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopeProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.ScopeContext properties-dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="excludeEmptyProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to exclude null/empty properties from the log event (as JSON)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="excludeProperties" type="xs:string">
           <xs:annotation>
-            <xs:documentation>List of property names to exclude when  is true</xs:documentation>
+            <xs:documentation>List of property names to exclude when P:NLog.Layouts.JsonLayout.IncludeAllProperties is true</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="includeAllProperties" type="xs:boolean">
+        <xs:attribute name="indentJson" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Option to include all properties from the log event (as JSON)</xs:documentation>
+            <xs:documentation>Auto indent and create new lines</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="includeMdc" type="xs:boolean">
+        <xs:attribute name="maxRecursionLimit" type="xs:integer">
           <xs:annotation>
-            <xs:documentation>Indicates whether to include contents of the  dictionary.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeMdlc" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include contents of the  dictionary.</xs:documentation>
+            <xs:documentation>How far should the JSON serializer follow object references before backing off</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="renderEmptyObject" type="xs:boolean">
@@ -2783,58 +4462,19 @@
         </xs:attribute>
         <xs:attribute name="suppressSpaces" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Option to suppress the extra spaces in the output json</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="maxRecursionLimit" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>How far should the JSON serializer follow object references before backing off</xs:documentation>
+            <xs:documentation>Option to suppress the extra spaces in the output json.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  <xs:complexType name="NLog.Layouts.JsonAttribute">
-    <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-      <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
-      <xs:element name="encode" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-      <xs:element name="escapeUnicode" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-      <xs:element name="includeEmptyValue" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-    </xs:choice>
-    <xs:attribute name="layout" type="SimpleLayoutAttribute">
-      <xs:annotation>
-        <xs:documentation>Layout that will be rendered as the attribute's value.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="name" type="xs:string">
-      <xs:annotation>
-        <xs:documentation>Name of the attribute.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="encode" type="xs:boolean">
-      <xs:annotation>
-        <xs:documentation>Determines wether or not this attribute will be Json encoded.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="escapeUnicode" type="xs:boolean">
-      <xs:annotation>
-        <xs:documentation>Indicates whether to escape non-ascii characters</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="includeEmptyValue" type="xs:boolean">
-      <xs:annotation>
-        <xs:documentation>Whether an attribute with empty value should be included in the output</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-  </xs:complexType>
   <xs:complexType name="LayoutWithHeaderAndFooter">
     <xs:complexContent>
       <xs:extension base="Layout">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="footer" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="header" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="footer" type="SimpleLayoutAttribute">
           <xs:annotation>
@@ -2858,35 +4498,161 @@
     <xs:complexContent>
       <xs:extension base="Layout">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="includeAllProperties" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeMdc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeMdlc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeNdc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="includeNdlc" minOccurs="0" maxOccurs="1" type="xs:boolean" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeNdc" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeScopeNested" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeScopeProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="layout" minOccurs="0" maxOccurs="unbounded" type="Layout" />
+          <xs:element name="ndcItemSeparator" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="scopeNestedSeparator" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="writeThrowableCData" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="appInfo" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="formattedMessage" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="includeCallSite" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeSourceInfo" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="loggerName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.Log4JXmlEventParameter" />
         </xs:choice>
-        <xs:attribute name="includeAllProperties" type="xs:boolean">
+        <xs:attribute name="includeEventProperties" type="xs:boolean">
           <xs:annotation>
             <xs:documentation>Option to include all properties from the log events</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="includeMdc" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include contents of the  dictionary.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="includeMdlc" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Indicates whether to include contents of the  dictionary.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="includeNdc" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Indicates whether to include contents of the  stack.</xs:documentation>
+            <xs:documentation>Whether to include log4j:NDC in output from T:NLog.ScopeContext nested context.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="includeNdlc" type="xs:boolean">
+        <xs:attribute name="includeScopeNested" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Indicates whether to include contents of the  stack.</xs:documentation>
+            <xs:documentation>Whether to include log4j:NDC in output from T:NLog.ScopeContext nested context.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopeProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.ScopeContext properties-dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="ndcItemSeparator" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Stack separator for log4j:NDC in output from T:NLog.ScopeContext nested context.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="scopeNestedSeparator" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Stack separator for log4j:NDC in output from T:NLog.ScopeContext nested context.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="writeThrowableCData" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether the log4j:throwable xml-element should be written as CDATA</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="appInfo" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Log4j:event log4japp-xml-element. By default it's the friendly name of the current AppDomain.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="formattedMessage" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Log4j:event message-xml-element. Default: ${message}</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeCallSite" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to include call site (class and method name) in the information sent over the network.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeSourceInfo" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to include source info (file name and line number) in the information sent over the network.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="loggerName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Log4j:event logger-xml-attribute. Default: ${logger}</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="MicrosoftConsoleJsonLayout">
+    <xs:complexContent>
+      <xs:extension base="Layout">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="attribute" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.JsonAttribute" />
+          <xs:element name="dottedRecursion" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeGdc" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeScopeProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="excludeEmptyProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="excludeProperties" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="indentJson" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="maxRecursionLimit" type="xs:integer" minOccurs="0" maxOccurs="1" default="1" />
+          <xs:element name="renderEmptyObject" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="suppressSpaces" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeScopes" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="state" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.JsonAttribute" />
+          <xs:element name="timestampFormat" type="xs:string" minOccurs="0" maxOccurs="1" default="o" />
+        </xs:choice>
+        <xs:attribute name="dottedRecursion" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to flatten nested object properties using dotted notation (avoid nested JSON output)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeEventProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the P:NLog.LogEventInfo.Properties dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeGdc" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.GlobalDiagnosticsContext dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopeProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.ScopeContext properties-dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="excludeEmptyProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to exclude null/empty properties from the log event (as JSON)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="excludeProperties" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>List of property names to exclude when P:NLog.Layouts.JsonLayout.IncludeAllProperties is true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="indentJson" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Auto indent and create new lines</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxRecursionLimit" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>How far should the JSON serializer follow object references before backing off</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="renderEmptyObject" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to render the empty object value {}</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="suppressSpaces" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to suppress the extra spaces in the output json.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopes" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include "scopes"-section</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="timestampFormat" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Whether to include "Timestamp"-section</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
@@ -2895,23 +4661,468 @@
   <xs:complexType name="SimpleLayout">
     <xs:complexContent>
       <xs:extension base="Layout">
+        <xs:choice minOccurs="0" maxOccurs="unbounded" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="SplunkLayout">
+    <xs:complexContent>
+      <xs:extension base="Layout">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="text" minOccurs="0" maxOccurs="1" type="xs:string" />
+          <xs:element name="attribute" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.JsonAttribute" />
+          <xs:element name="dottedRecursion" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeGdc" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="indentJson" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="maxRecursionLimit" type="xs:integer" minOccurs="0" maxOccurs="1" default="1" />
+          <xs:element name="renderEmptyObject" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="suppressSpaces" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="excludeEmptyProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="excludeProperties" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="includeScopeProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="SplunkField" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.JsonAttribute" />
+          <xs:element name="splunkHostName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="splunkIndex" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="splunkSourceName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="splunkSourceType" type="Layout" minOccurs="0" maxOccurs="1" />
         </xs:choice>
-        <xs:attribute name="text" type="xs:string">
+        <xs:attribute name="dottedRecursion" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation>Layout text.</xs:documentation>
+            <xs:documentation>Whether to flatten nested object properties using dotted notation (avoid nested JSON output)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeGdc" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.GlobalDiagnosticsContext dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="indentJson" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Auto indent and create new lines</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxRecursionLimit" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>How far should the JSON serializer follow object references before backing off</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="renderEmptyObject" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to render the empty object value {}</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="suppressSpaces" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to suppress the extra spaces in the output json.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="excludeEmptyProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to exclude null/empty properties from the log event (as JSON)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="excludeProperties" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>List of property names to exclude when P:NLog.Layouts.SplunkLayout.IncludeEventProperties is true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeEventProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Option to include all properties from the log events</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopeProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.ScopeContext properties-dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="splunkHostName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Splunk Message Host-attribute</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="splunkIndex" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Splunk Message Index-attribute, that controls which event data is to be indexed.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="splunkSourceName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Splunk Message Source-attribute. Example the name of the application.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="splunkSourceType" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Splunk Message SourceType-attribute. SourceType can be used hint for choosing Splunk Indexer</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  <xs:complexType name="SyslogLayout">
+    <xs:complexContent>
+      <xs:extension base="Layout">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="layout" minOccurs="0" maxOccurs="unbounded" type="Layout" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="rfc3164" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="rfc5424" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="structuredDataId" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="StructuredDataParam" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.TargetPropertyWithContext" />
+          <xs:element name="syslogAppName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="syslogFacility" type="NLog.Layouts.SyslogFacility" minOccurs="0" maxOccurs="1" default="User" />
+          <xs:element name="syslogHostName" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="syslogLevel" type="NLog.Layouts.SyslogLevel" minOccurs="0" maxOccurs="1" />
+          <xs:element name="syslogMessage" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="syslogMessageId" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="syslogProcessId" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="syslogTimestamp" type="Layout" minOccurs="0" maxOccurs="1" />
+        </xs:choice>
+        <xs:attribute name="includeEventProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether LogEvent Properties should be included for StructuredData when P:NLog.Layouts.SyslogLayout.Rfc5424 = true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="rfc3164" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to use RFC 3164 for Syslog Format</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="rfc5424" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Indicates whether to use RFC 5424 for Syslog Format</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="structuredDataId" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Prefix for StructuredData when P:NLog.Layouts.SyslogLayout.Rfc5424 = true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="syslogAppName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Name of the device / application / process sending the Syslog-message (Optional)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="syslogFacility" type="NLog.Layouts.SyslogFacility">
+          <xs:annotation>
+            <xs:documentation>Device Facility</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="syslogHostName" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>The FQDN or IPv4 address or IPv6 address or hostname of the sender machine (Optional)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="syslogLevel" type="NLog.Layouts.SyslogLevel">
+          <xs:annotation>
+            <xs:documentation>Message Severity</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="syslogMessage" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Mesage Payload</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="syslogMessageId" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>The type of message that should be the same for events with the same semantics. Ex ${event-properties:EventId} (Optional)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="syslogProcessId" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Process Id or Process Name or Logger Name (Optional)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="syslogTimestamp" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Indicates what DateTime format should be used when P:NLog.Layouts.SyslogLayout.Rfc5424 = true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="W3CExtendedLogLayout">
+    <xs:complexContent>
+      <xs:extension base="Layout">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="footer" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="header" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="lineEnding" type="LineEndingMode" minOccurs="0" maxOccurs="1" />
+          <xs:element name="directive" minOccurs="0" maxOccurs="unbounded" type="NLog.Web.Layouts.W3CExtendedLogField" />
+          <xs:element name="field" minOccurs="0" maxOccurs="unbounded" type="NLog.Web.Layouts.W3CExtendedLogField" />
+        </xs:choice>
+        <xs:attribute name="footer" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Footer layout.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="header" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Header layout.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="layout" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Body layout (can be repeated multiple times).</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="lineEnding" type="LineEndingMode">
+          <xs:annotation>
+            <xs:documentation>Newline to append after each directive header</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="NLog.Web.Layouts.W3CExtendedLogField">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+    </xs:choice>
+    <xs:attribute name="layout" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Layout of the field.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Name of the field.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="XmlLayout">
+    <xs:complexContent>
+      <xs:extension base="Layout">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="attribute" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.XmlAttribute" />
+          <xs:element name="contextproperty" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.TargetPropertyWithContext" />
+          <xs:element name="elementName" type="xs:string" minOccurs="0" maxOccurs="1" default="logevent" />
+          <xs:element name="element" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.XmlElement" />
+          <xs:element name="elementValue" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="includeScopeProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="excludeProperties" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="indentXml" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="maxRecursionLimit" type="xs:integer" minOccurs="0" maxOccurs="1" default="1" />
+          <xs:element name="propertiesCollectionItemName" type="xs:string" minOccurs="0" maxOccurs="1" default="item" />
+          <xs:element name="propertiesElementKeyAttribute" type="xs:string" minOccurs="0" maxOccurs="1" default="key" />
+          <xs:element name="propertiesElementName" type="xs:string" minOccurs="0" maxOccurs="1" default="property" />
+          <xs:element name="propertiesElementValueAttribute" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="elementEncode" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+          <xs:element name="includeEmptyValue" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+        </xs:choice>
+        <xs:attribute name="elementName" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Name of the root XML element</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="elementValue" type="SimpleLayoutAttribute">
+          <xs:annotation>
+            <xs:documentation>Value inside the root XML element</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeScopeProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the T:NLog.ScopeContext properties-dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="excludeProperties" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>List of property names to exclude when P:NLog.Layouts.XmlElementBase.IncludeEventProperties is true</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="indentXml" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Auto indent and create new lines</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxRecursionLimit" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>How far should the XML serializer follow object references before backing off</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="propertiesCollectionItemName" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>XML element name to use for rendering IList-collections items</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="propertiesElementKeyAttribute" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>XML attribute name to use when rendering property-key When null (or empty) then key-attribute is not included</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="propertiesElementName" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>XML element name to use when rendering properties</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="propertiesElementValueAttribute" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>XML attribute name to use when rendering property-value When null (or empty) then value-attribute is not included and value is formatted as XML-element-value.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="elementEncode" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Determines whether or not this attribute will be Xml encoded.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeEmptyValue" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether empty XML-element should be included in the output.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="includeEventProperties" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to include the contents of the P:NLog.LogEventInfo.Properties dictionary.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="NLog.Layouts.XmlAttribute">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="defaultValue" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="encode" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+      <xs:element name="includeEmptyValue" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+      <xs:element name="valueType" type="xs:string" minOccurs="0" maxOccurs="1" />
+    </xs:choice>
+    <xs:attribute name="name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Name of the attribute.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="layout" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Layout used for rendering the attribute value.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="defaultValue" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Fallback value when result value is not available</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="encode" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Whether output should be encoded with Xml-string escaping, or be treated as valid xml-attribute-value</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="includeEmptyValue" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Whether empty attribute value should be included in the output.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="valueType" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Result value type, for conversion of layout rendering output</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="NLog.Layouts.XmlElement">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" default="item" />
+      <xs:element name="attribute" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.XmlAttribute" />
+      <xs:element name="contextproperty" minOccurs="0" maxOccurs="unbounded" type="NLog.Targets.TargetPropertyWithContext" />
+      <xs:element name="element" minOccurs="0" maxOccurs="unbounded" type="NLog.Layouts.XmlElement" />
+      <xs:element name="includeScopeProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+      <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="value" type="Layout" minOccurs="0" maxOccurs="1" />
+      <xs:element name="encode" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true" />
+      <xs:element name="excludeProperties" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="indentXml" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+      <xs:element name="maxRecursionLimit" type="xs:integer" minOccurs="0" maxOccurs="1" default="1" />
+      <xs:element name="propertiesCollectionItemName" type="xs:string" minOccurs="0" maxOccurs="1" default="item" />
+      <xs:element name="propertiesElementKeyAttribute" type="xs:string" minOccurs="0" maxOccurs="1" default="key" />
+      <xs:element name="propertiesElementName" type="xs:string" minOccurs="0" maxOccurs="1" default="property" />
+      <xs:element name="propertiesElementValueAttribute" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="cDataEncode" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+      <xs:element name="includeEmptyValue" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+      <xs:element name="includeEventProperties" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+    </xs:choice>
+    <xs:attribute name="name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Name of the element</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="includeScopeProperties" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Whether to include the contents of the T:NLog.ScopeContext properties-dictionary.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="layout" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Layout used for rendering the XML-element InnerText.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="value" type="SimpleLayoutAttribute">
+      <xs:annotation>
+        <xs:documentation>Value inside the element</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="encode" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Whether output should be encoded with XML-string escaping, or be treated as valid xml-element-value</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="excludeProperties" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>List of property names to exclude when P:NLog.Layouts.XmlElementBase.IncludeEventProperties is true</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="indentXml" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Auto indent and create new lines</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="maxRecursionLimit" type="xs:integer">
+      <xs:annotation>
+        <xs:documentation>How far should the XML serializer follow object references before backing off</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="propertiesCollectionItemName" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>XML element name to use for rendering IList-collections items</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="propertiesElementKeyAttribute" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>XML attribute name to use when rendering property-key When null (or empty) then key-attribute is not included</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="propertiesElementName" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>XML element name to use when rendering properties</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="propertiesElementValueAttribute" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>XML attribute name to use when rendering property-value When null (or empty) then value-attribute is not included and value is formatted as XML-element-value.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="cDataEncode" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Whether output should be wrapped using CDATA section instead of XML-string escaping</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="includeEmptyValue" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Whether empty XML-element should be included in the output.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="includeEventProperties" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Whether to include the contents of the P:NLog.LogEventInfo.Properties dictionary.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
   <xs:complexType name="when">
     <xs:complexContent>
       <xs:extension base="Filter">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="action" minOccurs="0" maxOccurs="1" type="FilterResult" />
-          <xs:element name="condition" minOccurs="0" maxOccurs="1" type="Condition" />
+          <xs:element name="action" type="FilterResult" minOccurs="0" maxOccurs="1" default="Neutral" />
+          <xs:element name="condition" type="Condition" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="action" type="FilterResult">
           <xs:annotation>
@@ -2939,10 +5150,10 @@
     <xs:complexContent>
       <xs:extension base="Filter">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="action" minOccurs="0" maxOccurs="1" type="FilterResult" />
-          <xs:element name="ignoreCase" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="substring" minOccurs="0" maxOccurs="1" type="xs:string" />
+          <xs:element name="action" type="FilterResult" minOccurs="0" maxOccurs="1" default="Neutral" />
+          <xs:element name="ignoreCase" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="substring" type="xs:string" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="action" type="FilterResult">
           <xs:annotation>
@@ -2971,10 +5182,10 @@
     <xs:complexContent>
       <xs:extension base="Filter">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="action" minOccurs="0" maxOccurs="1" type="FilterResult" />
-          <xs:element name="compareTo" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="ignoreCase" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
+          <xs:element name="action" type="FilterResult" minOccurs="0" maxOccurs="1" default="Neutral" />
+          <xs:element name="compareTo" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="ignoreCase" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="action" type="FilterResult">
           <xs:annotation>
@@ -3003,10 +5214,10 @@
     <xs:complexContent>
       <xs:extension base="Filter">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="action" minOccurs="0" maxOccurs="1" type="FilterResult" />
-          <xs:element name="ignoreCase" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="substring" minOccurs="0" maxOccurs="1" type="xs:string" />
+          <xs:element name="action" type="FilterResult" minOccurs="0" maxOccurs="1" default="Neutral" />
+          <xs:element name="ignoreCase" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="substring" type="xs:string" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="action" type="FilterResult">
           <xs:annotation>
@@ -3035,10 +5246,10 @@
     <xs:complexContent>
       <xs:extension base="Filter">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="action" minOccurs="0" maxOccurs="1" type="FilterResult" />
-          <xs:element name="compareTo" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="ignoreCase" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
+          <xs:element name="action" type="FilterResult" minOccurs="0" maxOccurs="1" default="Neutral" />
+          <xs:element name="compareTo" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="ignoreCase" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
         </xs:choice>
         <xs:attribute name="action" type="FilterResult">
           <xs:annotation>
@@ -3067,26 +5278,30 @@
     <xs:complexContent>
       <xs:extension base="Filter">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="action" minOccurs="0" maxOccurs="1" type="FilterResult" />
-          <xs:element name="defaultFilterCacheSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="includeFirst" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
-          <xs:element name="maxFilterCacheSize" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="maxLength" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="timeoutSeconds" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="optimizeBufferDefaultLength" minOccurs="0" maxOccurs="1" type="xs:integer" />
-          <xs:element name="optimizeBufferReuse" minOccurs="0" maxOccurs="1" type="xs:boolean" />
-          <xs:element name="filterCountMessageAppendFormat" minOccurs="0" maxOccurs="1" type="xs:string" />
-          <xs:element name="filterCountPropertyName" minOccurs="0" maxOccurs="1" type="xs:string" />
+          <xs:element name="action" type="FilterResult" minOccurs="0" maxOccurs="1" default="Neutral" />
+          <xs:element name="filterCountMessageAppendFormat" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="filterCountPropertyName" type="xs:string" minOccurs="0" maxOccurs="1" />
+          <xs:element name="includeFirst" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false" />
+          <xs:element name="layout" type="Layout" minOccurs="0" maxOccurs="1" />
+          <xs:element name="maxLength" type="xs:integer" minOccurs="0" maxOccurs="1" default="1000" />
+          <xs:element name="timeoutSeconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="10" />
+          <xs:element name="defaultFilterCacheSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="1000" />
+          <xs:element name="maxFilterCacheSize" type="xs:integer" minOccurs="0" maxOccurs="1" default="50000" />
+          <xs:element name="optimizeBufferDefaultLength" type="xs:integer" minOccurs="0" maxOccurs="1" default="1000" />
         </xs:choice>
         <xs:attribute name="action" type="FilterResult">
           <xs:annotation>
             <xs:documentation>Action to be taken when filter matches.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="defaultFilterCacheSize" type="xs:integer">
+        <xs:attribute name="filterCountMessageAppendFormat" type="xs:string">
           <xs:annotation>
-            <xs:documentation>Default number of unique filter values to expect, will automatically increase if needed</xs:documentation>
+            <xs:documentation>Append FilterCount to the P:NLog.LogEventInfo.Message when an event is no longer filtered</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="filterCountPropertyName" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>Insert FilterCount value into P:NLog.LogEventInfo.Properties when an event is no longer filtered</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="includeFirst" type="xs:boolean">
@@ -3099,11 +5314,6 @@
             <xs:documentation>Layout to be used to filter log messages.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="maxFilterCacheSize" type="xs:integer">
-          <xs:annotation>
-            <xs:documentation>Max number of unique filter values to expect simultaneously</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="maxLength" type="xs:integer">
           <xs:annotation>
             <xs:documentation>Max length of filter values, will truncate if above limit</xs:documentation>
@@ -3114,24 +5324,19 @@
             <xs:documentation>How long before a filter expires, and logging is accepted again</xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="defaultFilterCacheSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Default number of unique filter values to expect, will automatically increase if needed</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxFilterCacheSize" type="xs:integer">
+          <xs:annotation>
+            <xs:documentation>Max number of unique filter values to expect simultaneously</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="optimizeBufferDefaultLength" type="xs:integer">
           <xs:annotation>
             <xs:documentation>Default buffer size for the internal buffers</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="optimizeBufferReuse" type="xs:boolean">
-          <xs:annotation>
-            <xs:documentation>Reuse internal buffers, and doesn't have to constantly allocate new buffers</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="filterCountMessageAppendFormat" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>Append FilterCount to the  when an event is no longer filtered</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="filterCountPropertyName" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>Insert FilterCount value into  when an event is no longer filtered</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>


### PR DESCRIPTION
## Summary

- **Newtonsoft.Json** 13.0.3 → 13.0.4 (patch; vulnerability fixes)
- **CsvHelper** 33.0.1 → 33.1.0 (minor)
- **NLog** 5.3.4 → 6.1.3 (major); **NLog.Extensions.Logging** 5.3.15 → 6.1.3; **NLog.Schema** 5.3.4 → 6.1.3 (XSD updated to match)
- **Remove `Microsoft.EntityFrameworkCore.SqlServer`** from CPM and `ProjectV.DataAccessLayer.csproj` per design decision D-11 (only active EF provider is Npgsql; `System.Data.SqlClient` pin preserved per D-10)
- Explicit no-ops: `Acolyte.NET` 3.0.0-alpha.51 (D-08), `JsonSubTypes` 2.0.1, `FileHelpers` 3.5.2, `Gridsum.DataflowEx` 2.0.0, `FSharp.Core` 8.0.400 (D-09), `Microsoft.AspNet.WebApi.Client` 6.0.0

## D-11 Verification

Gate 1 (`SqlConnection` / `SqlCommand` usage): **ZERO hits** — no raw SQL Server connections in `ProjectV.DataAccessLayer/`.

Gate 2 (SQLStatements* resource class consumers in `.cs` files): **ZERO hits** — the four `.resx` fragments (`SQLStatementsForCommon`, `SQLStatementsForRatings`, `SQLStatementsForResults`, `SQLStatementsForTmdb`) are unreferenced scaffolding, retained for future use per D-11.

## NLog 6.x Compatibility

Custom renderers (`IndentExceptionLayoutRenderer`, `ReplaceNewLinesFormatWrapperLayoutRenderer`) compiled against NLog 6.1.3 with **zero code changes** — base classes `LayoutRenderer` and `WrapperLayoutRendererBase` are API-stable across 5.x → 6.x.

## Test Plan

- [x] `dotnet restore ProjectV.sln` — clean (no NU errors)
- [x] `dotnet build ProjectV.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test ProjectV.sln -c Release --no-build` — all C# tests pass (14 passed, 1 skipped)
- [x] `dotnet test Tests/ProjectV.ContentDirectories.Tests/... -c Release -p:Platform=x64 --no-build` — 9/9 F# tests passed

Related to #300, #301 (NET-01, NET-02 — Phase 1 dependency upgrade requirements).

Contributes to Phase 1 Milestone: bump every NuGet package to net10.0-compatible versions.