### PR TITLE
phase(01-09): add Linux CI workflow + workflow updates for net10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+# build.yml — Linux+Windows GitHub Actions build matrix. Per D-26. Linux owns tests; Windows tests live on AppVeyor (D-24).
+# No NuGet caching: the repo has no packages.lock.json, so a cache key would be unstable.
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0'
+
+      - name: Restore
+        run: dotnet restore ProjectV/ProjectV.sln
+
+      - name: Restore (Desktop solution, Windows only)
+        if: matrix.os == 'windows-latest'
+        run: dotnet restore ProjectV/ProjectV.Desktop.sln
+
+      - name: Build (cross-platform solution)
+        run: dotnet build ProjectV/ProjectV.sln --configuration Release --no-restore
+
+      - name: Build (Desktop solution, Windows only)
+        if: matrix.os == 'windows-latest'
+        run: dotnet build ProjectV/ProjectV.Desktop.sln --configuration Release --no-restore
+
+      - name: Format check
+        run: dotnet format ProjectV --severity warn --verify-no-changes
+
+      - name: Test (C# projects)
+        if: matrix.os == 'ubuntu-latest'
+        run: dotnet test ProjectV/ProjectV.sln --configuration Release --no-build
+
+      - name: Test (F# ContentDirectories)
+        if: matrix.os == 'ubuntu-latest'
+        run: dotnet test ProjectV/Tests/ProjectV.ContentDirectories.Tests/ProjectV.ContentDirectories.Tests.fsproj --configuration Release

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, develop]
+    branches: [master]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
@@ -41,8 +41,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        # CodeQL fails to build .NET 8 projects.
-        dotnet-version: '8.0'
+        dotnet-version: '10.0'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ after_test:
   # F# tests does not execute at all.
   - ps: dotnet test --configuration $env:configuration --no-build "ProjectV/Tests/ProjectV.ContentDirectories.Tests/ProjectV.ContentDirectories.Tests.fsproj"
   # Check code style.
-  #- ps: dotnet format ProjectV --severity warn --verbosity diagnostic --verify-no-changes
+  - ps: dotnet format ProjectV --severity warn --verbosity diagnostic --verify-no-changes
 
 pull_requests:
     do_not_increment_build_number: true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build.yml`: Linux+Windows matrix CI (ubuntu-latest, windows-latest), .NET 10, Linux owns tests, Windows adds Desktop.sln build. Job names produce `Build (ubuntu-latest)` / `Build (windows-latest)` required-status-check contexts per D-26.
- Updates `.github/workflows/codeql-analysis.yml`: drops `develop` from `push.branches` (master-only per D-15/D-27), bumps `dotnet-version` from `'8.0'` to `'10.0'`, removes stale .NET 8 comment.
- Enables `appveyor.yml` `dotnet format` step (uncomments the line per D-25).

closes #303

## AppVeyor dotnet format outcome

The `dotnet format` step has been uncommented. If this step fails on AppVeyor with a "non-existing" style error, the contingency per D-25 applies: re-comment the line and file a follow-up backlog Issue.

## Next step (manual — after first build.yml run on master)

Once this PR merges into master and `build.yml` has its first successful run, update branch protection to add the two new check names. See the `DEFERRED: Branch protection update` section in `01-09-SUMMARY.md` for the exact `gh api` payload. The check names cannot be registered until the workflow runs at least once on master.

## Test plan

- [x] Local: `dotnet restore ProjectV/ProjectV.sln` — clean
- [x] Local: `dotnet build ProjectV/ProjectV.sln -c Release` — 0 warnings, 0 errors
- [x] Local: `dotnet test ProjectV/ProjectV.sln -c Release --no-build` — all pass
- [x] Local: `dotnet test ProjectV/Tests/ProjectV.ContentDirectories.Tests/...fsproj -c Release --no-build` — all pass
- [x] YAML lint: all three workflow files parse cleanly with `python3 -c "import yaml; yaml.safe_load(...)"`
- [ ] AppVeyor CI: awaiting first run on this PR
- [ ] GitHub Actions build.yml: awaiting first run on this PR