### PR TITLE
phase(01-10): swap FluentAssertions 6.x → AwesomeAssertions (license-change replacement)

### DIFF
--- a/ProjectV/Directory.Packages.props
+++ b/ProjectV/Directory.Packages.props
@@ -3,12 +3,12 @@
   <ItemGroup>
     <PackageVersion Include="Acolyte.NET" Version="3.0.0-alpha.51" />
     <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="AutoMapper" Version="16.1.1" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="FileHelpers" Version="3.5.2" />
     <PackageVersion Include="FSharp.Core" Version="8.0.400" />
-    <PackageVersion Include="FluentAssertions" Version="6.7.0" />
     <PackageVersion Include="Google.Apis" Version="1.74.0" />
     <PackageVersion Include="Google.Apis.Auth" Version="1.74.0" />
     <PackageVersion Include="Google.Apis.Core" Version="1.74.0" />


### PR DESCRIPTION
## Summary

- Removes `FluentAssertions 6.7.0` from `Directory.Packages.props` (D-07 license-change replacement #1 of 3).
- Adds `AwesomeAssertions 9.4.0` — the community-maintained fork of FluentAssertions that kept the Apache 2.0 license. Namespace remains `FluentAssertions`, so no source changes are needed.
- Zero pre-swap call sites in test code (confirmed by `grep -rn FluentAssertions ProjectV/Tests/`): this is a pure CPM entry swap.
- Pre-positions the assertion library for Phase 2 test additions (TEST-02 domain unit tests).

## Changes

| File | Change |
|------|--------|
| `ProjectV/Directory.Packages.props` | Remove `FluentAssertions 6.7.0`; add `AwesomeAssertions 9.4.0` (alphabetically between `Asp.Versioning.Mvc` and `AutoMapper`) |

No `.csproj` files modified (no test project currently references FluentAssertions).  
No `.cs` source files modified.

## Test Plan

- [x] `dotnet restore ProjectV.sln` — exit 0, no NU errors
- [x] `dotnet build ProjectV.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test ProjectV.sln -c Release --no-build` — 24 passed, 1 skipped (pre-existing skip), 0 failed
- [x] `dotnet test Tests/ProjectV.ContentDirectories.Tests/… -c Release -p:Platform=x64 --no-build` — 9 passed, 0 failed

Closes #9