### PR TITLE
phase(01-11): swap Moq → NSubstitute (license-change replacement)

### DIFF
--- a/ProjectV/Directory.Packages.props
+++ b/ProjectV/Directory.Packages.props
@@ -35,12 +35,12 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NLog" Version="6.1.3" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.3" />
     <PackageVersion Include="NLog.Schema" Version="6.1.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="OmdbApiNet" Version="1.3.0" />
     <PackageVersion Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
     <PackageVersion Include="Prism.Unity" Version="9.0.537" />


### PR DESCRIPTION
## Summary

- Removes `Moq 4.20.72` from `Directory.Packages.props` (D-07 license-change replacement #2 of 3).
- Adds `NSubstitute 5.3.0` (BSD 3-Clause) — no SponsorLink concerns, supply chain verified via nuget.org.
- Zero pre-swap call sites in test code (confirmed by `grep -rn "using Moq" ProjectV/Tests/` returning empty): this is a pure CPM entry swap.
- Pre-positions NSubstitute for Phase 2 test additions.

## Changes

| File | Change |
|------|--------|
| `ProjectV/Directory.Packages.props` | Remove `Moq 4.20.72`; add `NSubstitute 5.3.0` (alphabetically between `NLog.Schema` and `Npgsql.EntityFrameworkCore.PostgreSQL`) |

No `.csproj` files modified (no test project currently references Moq).
No `.cs` source files modified.

## Test Plan

- [x] `dotnet restore ProjectV.sln` — exit 0, no NU errors
- [x] `dotnet build ProjectV.sln -c Release` — 0 warnings, 0 errors
- [x] `dotnet test ProjectV.sln -c Release --no-build` — 23 passed, 1 skipped (pre-existing skip), 0 failed
- [x] `dotnet test Tests/ProjectV.ContentDirectories.Tests/… -c Release -p:Platform=x64 --no-build` — 9 passed, 0 failed

Closes #9