### PR TITLE
phase(01-13): docs update for net10 stack, CONTRIBUTING.md, and ngrok cherry-pick

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to ProjectV
+
+Thank you for your interest in contributing to ProjectV!
+
+## Workflow
+
+ProjectV follows a **GitHub-Milestone-driven** development process:
+
+- **Phases and milestones:** Each development phase corresponds to one GitHub Milestone (e.g., `v0.9.7`). Milestones have no fixed deadlines — they ship when ready.
+- **Task tracking:** Each task is one GitHub Issue linked to the active milestone. The implementing developer/agent posts notes on the Issue summarising decisions, nuances, and progress as work proceeds.
+- **Pull requests:** Every PR must link at least one Issue using `closes #XXXX` (or `Part of #XXXX` for partial work) in the PR body. Opening a PR without a corresponding Issue is not allowed — create or find the Issue first.
+- **Target branch:** All PRs target `master` directly. There are no long-lived feature or integration branches.
+- **Branch naming:** Use descriptive short-lived branches (e.g., `phase-1/13-docs-and-cherry-pick`). Delete the branch after the PR merges.
+- **Note:** The `develop` branch was retired with Phase 1 (`v0.9.7`). `master` is the only long-lived branch on the remote.
+
+## Branch Protection
+
+The following rules are enforced on `master`:
+
+- **No direct pushes.** All changes must arrive via a Pull Request.
+- **Required status checks before merge:**
+  - AppVeyor (Windows build + test)
+  - Build / ubuntu-latest (GitHub Actions `build.yml`)
+  - Build / windows-latest (GitHub Actions `build.yml`)
+  - CodeQL
+- **Up-to-date requirement:** Branches must be up-to-date with `master` before merge (strict mode).
+- **Linear history:** Squash merge or rebase merge only. Merge commits are not permitted.
+- **Force-push blocked.**
+- **Self-approval allowed:** As a solo maintainer, the author may merge their own PR after all required status checks pass. A required reviewer count is not enforced.
+
+## Build and Test Commands
+
+All commands are run from the **repo root** (the directory containing this file):
+
+```shell
+# Restore NuGet packages
+dotnet restore ProjectV
+
+# Build the cross-platform solution (Linux + Windows)
+dotnet build ProjectV/ProjectV.sln
+
+# Build the Windows-only solution (includes WPF DesktopApp; Windows only)
+dotnet build ProjectV/ProjectV.Desktop.sln
+
+# Run all C# tests
+dotnet test ProjectV/ProjectV.sln
+
+# Run F# tests (separate step — not picked up by solution-level test discovery)
+dotnet test ProjectV/Tests/ProjectV.ContentDirectories.Tests/ProjectV.ContentDirectories.Tests.fsproj
+
+# Check code style (must produce no changes; mirrors the CI gate)
+dotnet format ProjectV --severity warn --verify-no-changes
+```
+
+**SDK requirement:** .NET 10 SDK is required locally. The WPF DesktopApp (`ProjectV.Desktop.sln`) requires Windows.
+
+## Code Style
+
+- **EditorConfig:** `.editorconfig` at `ProjectV/.editorconfig` is authoritative. Key rules: UTF-8 with BOM, 4-space indent, `System.*` usings first, block-scoped namespaces.
+- **Warnings as errors:** `TreatWarningsAsErrors=true` is global. Do not suppress warnings to make a build pass — fix the root cause.
+- **Central Package Management (CPM):** New NuGet packages add a `<PackageVersion>` entry in `ProjectV/Directory.Packages.props`. Individual `.csproj` files declare `<PackageReference Include="..." />` **without** a `Version` attribute.
+- **Platforms:** `x64` only. Never add `AnyCPU` configurations.
+- **Run `dotnet format`** before pushing to ensure the style gate passes in CI.
+
+## Reporting Issues
+
+Use the Issue templates in `.github/ISSUE_TEMPLATE/`:
+
+- **Bug report** — for regressions and incorrect behaviour.
+- **Feature request** — for new capabilities.
+- **Custom** — for anything that doesn't fit the above.
+
+Link every Issue to the active GitHub Milestone before starting work.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/Vasar007/ProjectV/blob/master/LICENSE)
 [![AppVeyor branch](https://img.shields.io/appveyor/ci/Vasar007/ProjectV/master.svg)](https://ci.appveyor.com/project/Vasar007/ProjectV)
+[![Build](https://github.com/Vasar007/ProjectV/actions/workflows/build.yml/badge.svg)](https://github.com/Vasar007/ProjectV/actions/workflows/build.yml)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FVasar007%2FProjectV.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2FVasar007%2FProjectV?ref=badge_shield)
 
 [![GitHub wiki](https://img.shields.io/badge/Docs-GitHub%20wiki-brightgreen)](https://github.com/Vasar007/ProjectV/wiki)
@@ -24,7 +25,7 @@ Evaluate your things (movies, games, books e.t.c.) automatically based on popula
 
 ## Dependencies
 
-Target .NET is 6.0 for all projects. Version of C# is 10.0, version of F# is 5.0.
+Target .NET is 10.0 for all projects. Version of C# is 12.0, version of F# is 8.0.
 
 You can install all dependencies using NuGet package manager.
 


### PR DESCRIPTION
## Summary

- Update `README.md`: replace stale `.NET 6.0 / C# 10.0 / F# 5.0` references with `.NET 10.0 / C# 12.0 / F# 8.0`; add GitHub Actions `build.yml` status badge after the AppVeyor badge.
- Create `CONTRIBUTING.md` at repo root documenting the GitHub-Milestone workflow, branch protection rules, build/test commands, code style, and issue reporting.
- Verify PR template and all ISSUE_TEMPLATE files are free of `develop` references (confirmed clean — no changes needed).
- Cherry-pick `e64ce63` (`config: remove ngrok local link`) from `develop`: **no-op — the change is already present in `master`** (the ngrok URL was already updated to `https://link.ngrok.io` in a prior commit). The intent of `e64ce63` is fulfilled.

## Discarded develop commits (rationale)

The following four `develop` commits are NOT cherry-picked and are formally discarded:

| Hash | Subject | Rationale |
|------|---------|-----------|
| `0af7b6e` | `config: remove Linux x64 because .NET 8 still imports Desktop app anyway` | Rolled back on develop; superseded by D-01/D-02 (two-sln split in Plan 01-02) |
| `3fea0b2` | `config: skip Desktop app for both Debug and Release` | Superseded by D-01/D-02 two-sln split |
| `7371f21` | `config: update NuGet packages` | Superseded by Phase 1 clean-room NuGet upgrade (Plans 01-03 through 01-08) |
| `fe62570` | `config: update some logic and NuGet packages (DO NOT UPDATE Authentication packages!!!)` | Superseded by Phase 1 clean-room NuGet upgrade |

## WORK-05 reference

See #309 — WORK-05 ("develop branch removed") is referenced informationally here. The actual `develop` deletion and WORK-05 closure happen in Plan 14 (phase closure PR).

## Template verification gate (D-30)

```
grep -l develop .github/pull_request_template.md .github/ISSUE_TEMPLATE/*.md
```

Result: no hits — all templates are develop-clean. No template changes required.

## Test plan

- `dotnet restore ProjectV` — clean, no NU errors
- `dotnet build ProjectV/ProjectV.sln -c Release` — succeeded, 0 warnings, 0 errors
- `dotnet test ProjectV/ProjectV.sln -c Release --no-build` — 14 passed, 9 passed, 1 skipped (pre-existing skip)
- `dotnet test ProjectV/Tests/ProjectV.ContentDirectories.Tests/ProjectV.ContentDirectories.Tests.fsproj -c Release -p:Platform=x64 --no-build` — 9 passed

## Code formatting

Markdown only — no C# changes. Checked manually for correct ATX headings, table alignment, and blank lines around headings/lists.

## Closing issues

No issue is closed by this PR directly (WORK-05 closes in Plan 14). This PR fulfils the documentation requirements for Phase 1's final autonomous plan.